### PR TITLE
Fuse absmax into rmsnorm backward

### DIFF
--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -15,12 +15,14 @@ void rmsnorm_forward(Tensor& out, Tensor& rms, const Tensor& inp, const Tensor& 
     }
 }
 
-void rmsnorm_backward(Tensor& dinp, Tensor& dweight, Tensor& scratch, const Tensor& dresidual, const Tensor& dout, const Tensor& inp, const Tensor& weight, const Tensor& rstd,
+void rmsnorm_backward(Tensor& dinp, Tensor& dweight, Tensor& scratch, const Tensor& dresidual, const Tensor& dout, const Tensor& inp, const Tensor& weight, const Tensor& rstd, float* abs_max_ptr,
                       int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream) {
     if(dinp.DType == ETensorDType::BF16) {
-        rmsnorm_backward(dinp.get<nv_bfloat16>(), dweight.get<nv_bfloat16>(), scratch.Data, dresidual.get<nv_bfloat16>(), dout.get<nv_bfloat16>(), inp.get<nv_bfloat16>(), weight.get<nv_bfloat16>(), rstd.get<float>(), B, T, C, dp, stream);
+        rmsnorm_backward(dinp.get<nv_bfloat16>(), dweight.get<nv_bfloat16>(), scratch.Data, dresidual.get<nv_bfloat16>(),
+            dout.get<nv_bfloat16>(), inp.get<nv_bfloat16>(), weight.get<nv_bfloat16>(), rstd.get<float>(), abs_max_ptr, B, T, C, dp, stream);
     } else if (dinp.DType == ETensorDType::FP32) {
-        rmsnorm_backward(dinp.get<float>(), dweight.get<float>(), scratch.Data, dresidual.get<float>(), dout.get<float>(), inp.get<float>(), weight.get<float>(), rstd.get<float>(), B, T, C, dp, stream);
+        rmsnorm_backward(dinp.get<float>(), dweight.get<float>(), scratch.Data, dresidual.get<float>(),
+            dout.get<float>(), inp.get<float>(), weight.get<float>(), rstd.get<float>(), abs_max_ptr, B, T, C, dp, stream);
     } else {
         throw std::logic_error("rmsnorm_backward: unsupported dtype");
     }

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -40,11 +40,11 @@ void rmsnorm_forward(nv_bfloat16* out, float* rms, const nv_bfloat16* inp, const
 void rmsnorm_forward(Tensor& out, Tensor& rms, const Tensor& inp, const Tensor& weight, float* abs_max_ptr, float epsilon, int B, int T, int C, cudaStream_t stream);
 
 int get_rmsnorm_backward_scratch_size(int C, const cudaDeviceProp& dp);
-void rmsnorm_backward(float* dinp, float* dweight, std::byte* scratch, const float* dresidual, const float* dout, const float* inp, const float* weight, const float* rstd,
+void rmsnorm_backward(float* dinp, float* dweight, std::byte* scratch, const float* dresidual, const float* dout, const float* inp, const float* weight, const float* rstd, float* abs_max_ptr,
                       int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream);
-void rmsnorm_backward(nv_bfloat16* dinp, nv_bfloat16* dweight, std::byte* scratch, const nv_bfloat16* dresidual, const nv_bfloat16* dout, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* rstd,
+void rmsnorm_backward(nv_bfloat16* dinp, nv_bfloat16* dweight, std::byte* scratch, const nv_bfloat16* dresidual, const nv_bfloat16* dout, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* rstd, float* abs_max_ptr,
                       int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream);
-void rmsnorm_backward(Tensor& dinp, Tensor& dweight, Tensor& scratch, const Tensor& dresidual, const Tensor& dout, const Tensor& inp, const Tensor& weight, const Tensor& rstd,
+void rmsnorm_backward(Tensor& dinp, Tensor& dweight, Tensor& scratch, const Tensor& dresidual, const Tensor& dout, const Tensor& inp, const Tensor& weight, const Tensor& rstd, float* abs_max_ptr,
                       int B, int T, int C,  const cudaDeviceProp& dp, cudaStream_t stream);
 
 void fused_residual_rmsnorm_forward(float* residual, float* normed, float* rrms, const float* inp1, const float* inp2, const float* weight, float* abs_max_ptr,

--- a/src/kernels/rmsnorm.cu
+++ b/src/kernels/rmsnorm.cu
@@ -266,15 +266,16 @@ template<class floatX>
 __global__ void __launch_bounds__(512, 2)
 rmsnorm_backward_kernel10(floatX* dinp, floatX* dweight, std::byte* scratch,
                           const floatX* dout, const floatX* inp, const floatX* weight,
-                          const float* rstd, int B, int T, int C) {
+                          const float* rstd, float* abs_max_ptr, int B, int T, int C) {
     // size of scratch: sizeof(float) * C + 128
     using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
     using f128 = GenericVector<float, 16/sizeof(float)>;
-    // TODO: this kernel uses too much shared memory due to historical reasons of it coming from layernorm_backward.cu
-    // this memory use can be reduced by half later
+
     int BLOCK_SIZE = blockDim.x;
     int warpsInBlock = BLOCK_SIZE / WARP_SIZE; //number of warps in block
     extern __shared__ float shared[];
+    __shared__ float block_max;
+    float thread_max = 0.f;
 
     int warpId = threadIdx.x / WARP_SIZE; // warp index within a block
     int baseIdx = blockIdx.x * warpsInBlock + warpId;
@@ -294,6 +295,9 @@ rmsnorm_backward_kernel10(floatX* dinp, floatX* dweight, std::byte* scratch,
     // init shared memory to zero
     for(int i = threadIdx.x * f128::size; i < rounded_C; i += BLOCK_SIZE * f128::size) {
         f128::zeros().store(dweight_shared + i);
+    }
+    if (abs_max_ptr && threadIdx.x == 0) {
+        block_max = 1e-10f;
     }
     __syncthreads();
 
@@ -383,10 +387,23 @@ rmsnorm_backward_kernel10(floatX* dinp, floatX* dweight, std::byte* scratch,
                 // cache in L2 as this is read by the next kernel, but bypass L1 to minimise thrashing
                 // TODO cache hint
                 dinp128.store(dinp_bt + global_index);
+
+                for(int i = 0; i < x128::size; ++i) {
+                    thread_max = std::max(thread_max, fabsf(dinp128[i]));
+                }
             }
         }
     }
     __syncthreads();
+    // if we requested an absmax, do the block-wise and global reduction
+    if (abs_max_ptr) {
+        atomicMax_block(reinterpret_cast<unsigned int*>(&block_max), __float_as_uint(thread_max));
+        __syncthreads();
+        if(threadIdx.x == 0) {
+            atomicMax(reinterpret_cast<unsigned int*>(abs_max_ptr), __float_as_uint(block_max));
+        }
+    }
+
     // Each block writes its partial sum to global memory
     // The last block to finish becomes responsible for summing up all the partial sums
     // This is done by atomically incrementing a flag (cleared to 0 before launching the kernel)
@@ -451,6 +468,7 @@ int get_rmsnorm_backward_scratch_size(int C, const cudaDeviceProp& dp) {
 template<class floatX>
 void rmsnorm_backward_imp(floatX* dinp, floatX* dweight, std::byte* scratch,
                           const floatX* dresidual, const floatX* dout, const floatX* inp, const floatX* weight, const float* rstd,
+                          float* abs_max_ptr,
                           int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream) {
     using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
     using f128 = GenericVector<float, 16/sizeof(float)>;
@@ -463,19 +481,22 @@ void rmsnorm_backward_imp(floatX* dinp, floatX* dweight, std::byte* scratch,
     if(dresidual != dinp) {
         CUDA_CHECK(cudaMemcpyAsync(dinp, dresidual, B*T*C * sizeof(floatX), cudaMemcpyDeviceToDevice, stream));
     }
+    if (abs_max_ptr) {
+        CUDA_CHECK(cudaMemsetAsync(abs_max_ptr, 0, sizeof(float), stream));
+    }
     CUDA_CHECK(cudaMemsetAsync(scratch, 0, 1 * sizeof(float), stream)); // only need to reset the flag to 0
-    rmsnorm_backward_kernel10<<<grid_size, block_size, shared_mem_size, stream>>>(dinp, dweight, scratch, dout, inp, weight, rstd, B, T, C);
+    rmsnorm_backward_kernel10<<<grid_size, block_size, shared_mem_size, stream>>>(dinp, dweight, scratch, dout, inp, weight, rstd, abs_max_ptr, B, T, C);
     CUDA_CHECK(cudaGetLastError());
 }
 
 void rmsnorm_backward(float* dinp, float* dweight, std::byte* scratch,
-                      const float* dresidual, const float* dout, const float* inp, const float* weight, const float* rstd,
+                      const float* dresidual, const float* dout, const float* inp, const float* weight, const float* rstd, float* abs_max_ptr,
                       int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream) {
-    rmsnorm_backward_imp(dinp, dweight, scratch, dresidual, dout, inp, weight, rstd, B, T, C, dp, stream);
+    rmsnorm_backward_imp(dinp, dweight, scratch, dresidual, dout, inp, weight, rstd, abs_max_ptr, B, T, C, dp, stream);
 }
 
 void rmsnorm_backward(nv_bfloat16* dinp, nv_bfloat16* dweight, std::byte* scratch,
-                      const nv_bfloat16* dresidual, const nv_bfloat16* dout, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* rstd,
+                      const nv_bfloat16* dresidual, const nv_bfloat16* dout, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* rstd, float* abs_max_ptr,
                       int B, int T, int C, const cudaDeviceProp& dp, cudaStream_t stream) {
-    rmsnorm_backward_imp(dinp, dweight, scratch, dresidual, dout, inp, weight, rstd, B, T, C, dp, stream);
+    rmsnorm_backward_imp(dinp, dweight, scratch, dresidual, dout, inp, weight, rstd, abs_max_ptr, B, T, C, dp, stream);
 }

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -348,7 +348,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     Parameters->gather_lnf(comm);
     // backward the final layernorm
     rmsnorm_backward(d_acts[L-1].DResFFN.Value, d_lnf_w, rs->RMSNormScratch, d_acts[L - 1].DResFFN.Value, rs->DLNF,
-                     rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, B, T, C, rs->DeviceProp, main_stream);
+                     rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);
     Parameters->release_lnf(main_stream);
     Grads->notify_lnf_w(main_stream, comm);
 
@@ -431,7 +431,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     // rmsnorm backward does += to the dresidual, so it correctly accumulates grad from the MLP block above
     rmsnorm_backward(d_acts.DResAtt.Value, d_weights.LN2_w, rs->RMSNormScratch, d_acts.DResFFN.Value, d_acts.DLN2,
-                     acts.ResidualAtt, weights.LN2_w, acts.LN2_Rstd, B, T, C, rs->DeviceProp, main_stream);
+                     acts.ResidualAtt, weights.LN2_w, acts.LN2_Rstd, d_acts.DResAtt.Quant.has_value() ? d_acts.DResAtt.Quant->Scales : nullptr, B, T, C, rs->DeviceProp, main_stream);
 
     bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
     if(recompute_ln1) {
@@ -457,7 +457,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     }
 
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
-                       accumulate, run_state, B, T, C, C, false, false, main_stream);
+                       accumulate, run_state, B, T, C, C, false, true, main_stream);
 
     attention_backward_cudnn(d_acts.DRope, acts.LSE, acts.Att.Value, d_acts.DAttY, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
     rope_backward(d_acts.DQKV.Value, d_acts.DRope, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
@@ -468,10 +468,10 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     if(layer > 0) {
         auto& prev_dacts = rs->DActs.at(layer - 1);
         rmsnorm_backward(prev_dacts.DResFFN.Value, d_weights.LN1_w, rs->RMSNormScratch, prev_dacts.DResAtt.Value, d_acts.DLN1,
-                         rs->Acts[layer - 1].ResidualFFN, weights.LN1_w, acts.LN1_Rstd, B, T, C, rs->DeviceProp, main_stream);
+                         rs->Acts[layer - 1].ResidualFFN, weights.LN1_w, acts.LN1_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);
     } else {
         rmsnorm_backward(rs->DEmb, d_weights.LN1_w, rs->RMSNormScratch, d_acts.DResAtt.Value, d_acts.DLN1,
-                         rs->Encoded, weights.LN1_w, acts.LN1_Rstd, B, T, C, rs->DeviceProp, main_stream);
+                         rs->Encoded, weights.LN1_w, acts.LN1_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);
     }
 }
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -351,7 +351,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     Parameters->gather_lnf(comm);
     // backward the final layernorm
     rmsnorm_backward(d_acts[L-1].DResFFN.Value, d_lnf_w, rs->RMSNormScratch, d_acts[L - 1].DResFFN.Value, rs->DLNF,
-                     rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);
+                     rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, quant_abs_max_ptr(d_acts[L-1].DResFFN), B, T, C, rs->DeviceProp, main_stream);
     Parameters->release_lnf(main_stream);
     Grads->notify_lnf_w(main_stream, comm);
 
@@ -421,7 +421,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     // backward the 2nd matmul of MLP
     backward_qmm(d_acts.DSwiGLU, d_weights.MLP_Down_w, std::nullopt, d_acts.DResFFN, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
-                       accumulate, run_state, B, T, D, C, reuse_swiglu, false, main_stream);
+                       accumulate, run_state, B, T, D, C, reuse_swiglu, true, main_stream);
 
     swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
 
@@ -471,7 +471,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     if(layer > 0) {
         auto& prev_dacts = rs->DActs.at(layer - 1);
         rmsnorm_backward(prev_dacts.DResFFN.Value, d_weights.LN1_w, rs->RMSNormScratch, prev_dacts.DResAtt.Value, d_acts.DLN1,
-                         rs->Acts[layer - 1].ResidualFFN, weights.LN1_w, acts.LN1_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);
+                         rs->Acts[layer - 1].ResidualFFN, weights.LN1_w, acts.LN1_Rstd, quant_abs_max_ptr(prev_dacts.DResFFN), B, T, C, rs->DeviceProp, main_stream);
     } else {
         rmsnorm_backward(rs->DEmb, d_weights.LN1_w, rs->RMSNormScratch, d_acts.DResAtt.Value, d_acts.DLN1,
                          rs->Encoded, weights.LN1_w, acts.LN1_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -71,6 +71,11 @@ void trace_or_execute_cuda_graph(Function&& function, cudaStream_t stream, cudaG
     }
 }
 
+/// If `tensor` has quants, return their scales; otherwise, return nullptr
+float* quant_abs_max_ptr(QuantizableTensor& tensor) {
+    return tensor.Quant.has_value() ? tensor.Quant->Scales : nullptr;
+}
+
 void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) {
     NVTX_RANGE_FN();
 
@@ -122,13 +127,12 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         // because this is a change in topology, this isn't part of the cuda graph
         if (l == 0) {
             rmsnorm_forward(rs->Acts[0].LN1.Value, rs->Acts[0].LN1_Rstd, rs->Encoded, wgt.LN1_w,
-                            rs->Acts[0].LN1.Quant.has_value() ? rs->Acts[0].LN1.Quant->Scales : nullptr,
-                            Config.RmsNormEps, B, T, C, main_stream);
+                            quant_abs_max_ptr(rs->Acts[0].LN1), Config.RmsNormEps, B, T, C, main_stream);
         } else if(l != Config.NumLayers) {
             auto& acts = rs->Acts[l-1];
             fused_residual_rmsnorm_forward(acts.ResidualFFN, rs->Acts[l].LN1.Value, rs->Acts[l].LN1_Rstd,
                                            acts.ResidualAtt, acts.MlpDown, wgt.LN1_w,
-                                           rs->Acts[l].LN1.Quant.has_value() ? rs->Acts[l].LN1.Quant->Scales : nullptr,
+                                           quant_abs_max_ptr(rs->Acts[l].LN1),
                                            Config.RmsNormEps, B * T, C, main_stream);
         }
 
@@ -190,14 +194,13 @@ void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights, 
                      rs->DeviceProp, false, false, main_stream);
 
     fused_residual_rmsnorm_forward(acts.ResidualAtt, acts.LN2.Value, acts.LN2_Rstd, residual, acts.AttO, weights.LN2_w,
-                                   acts.LN2.Quant.has_value() ? acts.LN2.Quant->Scales : nullptr,
-                                   Config.RmsNormEps, B * T, C, main_stream);
+                                   quant_abs_max_ptr(acts.LN2), Config.RmsNormEps, B * T, C, main_stream);
 
     forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
                      rs->CublasLtHandle, rs->Workspace,
                      B, T, C, 2 * D,
                      rs->DeviceProp, false, true, main_stream);
-    swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, acts.SwiGLu.Quant.has_value() ? acts.SwiGLu.Quant->Scales: nullptr, B, T, D, main_stream);
+    swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, quant_abs_max_ptr(acts.SwiGLu), B, T, D, main_stream);
 
     forward_qmm(acts.MlpDown, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
                      rs->CublasLtHandle, rs->Workspace,
@@ -420,7 +423,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     backward_qmm(d_acts.DSwiGLU, d_weights.MLP_Down_w, std::nullopt, d_acts.DResFFN, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
                        accumulate, run_state, B, T, D, C, reuse_swiglu, false, main_stream);
 
-    swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, d_acts.DMlpUp.Quant.has_value() ? d_acts.DMlpUp.Quant->Scales: nullptr, B, T, D, main_stream);
+    swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
 
     if(rs->Options.RecomputeRMSNorm && !rs->Options.RecomputeFFN) {
         rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
@@ -431,7 +434,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     // rmsnorm backward does += to the dresidual, so it correctly accumulates grad from the MLP block above
     rmsnorm_backward(d_acts.DResAtt.Value, d_weights.LN2_w, rs->RMSNormScratch, d_acts.DResFFN.Value, d_acts.DLN2,
-                     acts.ResidualAtt, weights.LN2_w, acts.LN2_Rstd, d_acts.DResAtt.Quant.has_value() ? d_acts.DResAtt.Quant->Scales : nullptr, B, T, C, rs->DeviceProp, main_stream);
+                     acts.ResidualAtt, weights.LN2_w, acts.LN2_Rstd, quant_abs_max_ptr(d_acts.DResAtt), B, T, C, rs->DeviceProp, main_stream);
 
     bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
     if(recompute_ln1) {


### PR DESCRIPTION
For a 0.5B model on 4090, this results in about 0.1% speedup (total step time is ~1300ms):

### New
| Time | Total Time | Instances | Avg | Name |
|------|------------|-----------|-----|------|
| 1.8% | 24.470 ms | 392 | 62.423 μs | `void rmsnorm_backward_kernel10<__nv_bfloat16>` |
| 0.1% | 1.918 ms | 384 | 4.994 μs | `void absmax_scale_kernel<__nv_bfloat16>` |

### Old
| Time | Total Time | Instances | Avg | Name |
|------|------------|-----------|-----|------|
| 1.8% | 24.249 ms | 392 | 61.859 μs | `void rmsnorm_backward_kernel10<__nv_bfloat16>` |
| 0.3% | 3.747 ms | 768 | 4.879 μs | `void absmax_scale_kernel<__nv_bfloat16>` |
