### PR TITLE
Recompute attention-residual

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Let's fine-tune the smallest Qwen model on this data:
   --eval-file=data/tiny-shakespeare-qwen/eval.bin \
   --model-dtype=bf16 --opt-m-dtype=bf16 --opt-v-dtype=bf16 \
   --matmul-dtype=e4m3 \
-  --recompute-ffn --recompute-att \
+  --recompute-block \
   --grad-accumulation=8 --steps=30 \
   --learning-rate=1e-5 --gpus=1 --batch-size=8
 ```
@@ -53,7 +53,7 @@ The program will print some logging information, such as the following:
 ```text
 [Options]
   recompute-swiglu  : true
-  recompute-norm    : false
+  recompute-norm    : true
   [...]
 
 [System 0]
@@ -83,7 +83,7 @@ Loading model from `/huggingface/hub/models--Qwen--Qwen2.5-0.5B/snapshots/060db6
 ```
 
 If `[Allocator State]` shows a lot of `Free` memory (as it does here), you can try increasing the batch size (and adjust `--grad-accumulation` accordingly), or reduce the amount of activation checkpointing.
-For example, on a 16GiB 4060Ti, `--recompute-ffn --recompute-att` can be replaced by `--recompute-swiglu`, which increases the activation memory from `4.5 GiB` to `9 GiB`, and
+For example, on a 16GiB 4060Ti, `--recompute-block` can be replaced by `--recompute-swiglu`, which increases the activation memory from `4.5 GiB` to `9 GiB`, and
 the speed from ~11k tps to ~13k tps.
 
 Then, the actual training will begin:
@@ -338,16 +338,19 @@ The run marked with * uses additional arguments `--shard-weights --memcpy-all-ga
 | Qwen2.5-3B²   | 4    | bf16  | 4     | 24k  | 69% | 12h   |
 | Qwen2.5-7B⁶   | 4    | fp8   | 8     | 13k  | 47% | 21h   |
 | Qwen2.5-7B⁷   | 4    | bf16  | 8     | 7.0k | 46% | 40h   |
-| Qwen2.5-14B⁶  | 4    | fp8   | 4     | 3.2k | 22% | 87h   |
-| Qwen2.5-14B⁷  | 4    | bf16  | 4     | 2.5k | 33% | 111h  |
+| Qwen2.5-14B⁸  | 4    | fp8   | 8     | 6.0k | 42% | 47h   |
+| Qwen2.5-14B⁹  | 4    | bf16  | 8     | 4.5k | 58% | 62h   |
+
 
 ^1: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm --offload-master`  
 ^2: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm`  
 ^3: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --persistent-quants --offload-quants`  
 ^4: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather`  
-^5: `--recompute-norm --recompute-swiglu`  
+^5: `--recompute-norm --recompute-swiglu` 
 ^6: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
-^7: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce`  
+^7: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce` 
+^8: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
+^9: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce`  
 
 ### L40S
 
@@ -379,38 +382,38 @@ The run marked with * uses additional arguments `--shard-weights --memcpy-all-ga
 
 ### RTX 5090 Performance Benchmarks
 
-| Model         | nGPU | DType | Batch | TPS | SOL  | TTB   |
-|---------------|------|-------|-------|-----|------|-------|
-| Qwen2.5-0.5B  | 1    | fp8   | 8     | 70k | 68%  | 4:00h |
-| Qwen2.5-0.5B  | 1    | fp8   | 16    | 69k | 67%  | 4:02h |
-| Qwen2.5-0.5B¹ | 1    | fp8   | 32    | 54k | 52%  | 5:08h |
-| Qwen2.5-0.5B  | 1    | bf16  | 8     | 55k | 81%  | 5:03h |
-| Qwen2.5-0.5B  | 1    | bf16  | 16    | 55k | 82%  | 5:03h |
-| Qwen2.5-0.5B¹ | 1    | bf16  | 32    | 48k | 71%  | 5:47h |
-| Qwen2.5-1.5B  | 1    | fp8   | 8     | 27k | 73%  | 10:16h|
-| Qwen2.5-1.5B¹ | 1    | bf16  | 8     | 17k | 77%  | 16:22h|
-| Qwen2.5-3B¹   | 1    | fp8   | 4     | 13k | 64%  | 21:24h|
-| Qwen2.5-3B¹   | 1    | fp8   | 8     | 13k | 64%  | 21:24h|
-| Qwen2.5-3B¹   | 1    | bf16  | 4     | 8.2k| 75%  | 33:53h|
-| Qwen2.5-3B¹   | 1    | bf16  | 8     | 8.6k| 78%  | 32:18h|
-| Qwen2.5-7B³   | 1    | fp8   | 4     | 3.2k| 36%  | 87h   |
-| Qwen2.5-7B³   | 1    | fp8   | 8     | 4.4k| 50%  | 63h   |
-| Qwen2.5-7B³   | 1    | bf16  | 4     | 2.5k| 52%  | 111h  |
-| Qwen2.5-7B³   | 1    | bf16  | 8     | 3.1k| 66%  | 90h   |
-| Qwen2.5-1.5B  | 4    | fp8   | 8     | 107k| 72%  | 2:36h |
-| Qwen2.5-1.5B⁴ | 4    | bf16  | 4     | 71.2k| 81% | 3:41h |
-| Qwen2.5-3B¹   | 4    | fp8   | 4     | 48k | 61%  | 5:47h |
-| Qwen2.5-3B²   | 4    | fp8   | 8     | 49k | 62%  | 5:40h |
-| Qwen2.5-3B¹   | 4    | bf16  | 4     | 32k | 72%  | 8:41h |
-| Qwen2.5-7B³   | 4    | fp8   | 8     | 18.9k| 53% | 14:42h|
-| Qwen2.5-7B³   | 4    | bf16  | 8     | 13.9k| 71% | 20:00h|
-| Qwen2.5-14B³  | 4    | fp8   | 4     | 8.1k| 23%  | 34:20h|
-| Qwen2.5-14B³  | 4    | bf16  | 4     | 3.9k| 20%  | 71:20h|
+| Model         | nGPU | DType | Batch | TPS   | SOL | TTB    |
+|---------------|------|-------|-------|-------|-----|--------|
+| Qwen2.5-0.5B  | 1    | fp8   | 8     | 70k   | 68% | 4:00h  |
+| Qwen2.5-0.5B  | 1    | fp8   | 16    | 69k   | 67% | 4:02h  |
+| Qwen2.5-0.5B¹ | 1    | fp8   | 32    | 54k   | 52% | 5:08h  |
+| Qwen2.5-0.5B  | 1    | bf16  | 8     | 55k   | 81% | 5:03h  |
+| Qwen2.5-0.5B  | 1    | bf16  | 16    | 55k   | 82% | 5:03h  |
+| Qwen2.5-0.5B¹ | 1    | bf16  | 32    | 48k   | 71% | 5:47h  |
+| Qwen2.5-1.5B  | 1    | fp8   | 8     | 27k   | 73% | 10:16h |
+| Qwen2.5-1.5B¹ | 1    | bf16  | 8     | 17k   | 77% | 16:22h |
+| Qwen2.5-3B¹   | 1    | fp8   | 4     | 13k   | 64% | 21:24h |
+| Qwen2.5-3B¹   | 1    | fp8   | 8     | 13k   | 64% | 21:24h |
+| Qwen2.5-3B¹   | 1    | bf16  | 4     | 8.2k  | 75% | 33:53h |
+| Qwen2.5-3B¹   | 1    | bf16  | 8     | 8.6k  | 78% | 32:18h |
+| Qwen2.5-7B³   | 1    | fp8   | 4     | 3.2k  | 36% | 87h    |
+| Qwen2.5-7B³   | 1    | fp8   | 8     | 4.4k  | 50% | 63h    |
+| Qwen2.5-7B³   | 1    | bf16  | 4     | 2.5k  | 52% | 111h   |
+| Qwen2.5-7B³   | 1    | bf16  | 8     | 3.1k  | 66% | 90h    |
+| Qwen2.5-1.5B  | 4    | fp8   | 8     | 107k  | 72% | 2:36h  |
+| Qwen2.5-1.5B⁴ | 4    | bf16  | 4     | 71.2k | 81% | 3:41h  |
+| Qwen2.5-3B¹   | 4    | fp8   | 4     | 48k   | 61% | 5:47h  |
+| Qwen2.5-3B²   | 4    | fp8   | 8     | 49k   | 62% | 5:40h  |
+| Qwen2.5-3B¹   | 4    | bf16  | 4     | 32k   | 72% | 8:41h  |
+| Qwen2.5-7B³   | 4    | fp8   | 8     | 18.9k | 53% | 14:42h |
+| Qwen2.5-7B³   | 4    | bf16  | 8     | 13.9k | 71% | 20:00h |
+| Qwen2.5-14B³  | 4    | fp8   | 4     | 8.1k  | 23% | 34:20h |
+| Qwen2.5-14B³  | 4    | bf16  | 4     | 3.9k  | 20% | 71:20h |
 
-¹: `--recompute-ffn --recompute-att`
-²: `--recompute-norm --recompute-swiglu --recompute-ffn --recompute-att`
-³: `--recompute-norm --recompute-swiglu --recompute-ffn --recompute-att --offload-opt-m --offload-opt-v --shard-weights --offload-master --shard-gradients`
-⁴: `--recompute-swiglu`
+¹: `--recompute-ffn --recompute-att` 
+²: `--recompute-norm --recompute-swiglu --recompute-ffn --recompute-att` 
+³: `--recompute-norm --recompute-swiglu --recompute-ffn --recompute-att --offload-opt-m --offload-opt-v --shard-weights --offload-master --shard-gradients` 
+⁴: `--recompute-swiglu` 
 
 Command used: `./build/train --model=./Qwen2.5-0.5B --train-file=tiny-shakespeare-qwen-train.bin --eval-file=tiny-shakespeare-qwen-eval.bin --model-dtype=bf16 --opt-m-dtype=bf16 --opt-v-dtype=bf16 --matmul-dtype=e4m3 --grad-accumulation=8 --steps=1000 --learning-rate=1e-5 --gpus=1 --batch-size=8`
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -416,11 +416,11 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
         // two scenarios: 1) we do not recompute the RMSnorm; then, we _will_ overwrite the full-precision copy of acts.LN1,
         //                   but _can_ reuse the quantized version
         //                2) we recompute RMSNorm; then, acts.LN1 will be correct, but its quantized version will not, so
-        //                   we have to re-quantize (TODO but we could reuse the absmax)
+        //                   we have to re-quantize
         forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
                      rs->CublasLtHandle, rs->Workspace,
                      B, T, C, Config.qkv_channels(),
-                     rs->DeviceProp, !recompute_ln1, false, main_stream);
+                     rs->DeviceProp, !recompute_ln1, true, main_stream);
         rope_forward(acts.Rope, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
     }
 
@@ -432,7 +432,7 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
             forward_qmm(acts.AttO, acts.Att, weights.Attn_Out_w, std::nullopt,
                          rs->CublasLtHandle, rs->Workspace,
                          B, T, C, C,
-                         rs->DeviceProp, false, false, main_stream);
+                         rs->DeviceProp, false, true, main_stream);
         }
     }
 
@@ -441,10 +441,10 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
         if (opt.RecomputeBlock) {
             Tensor residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
             fused_residual_rmsnorm_forward(acts.ResidualAtt, acts.LN2.Value, acts.LN2_Rstd, residual, acts.AttO, weights.LN2_w,
-                                       acts.LN2.Quant.has_value() ? acts.LN2.Quant->Scales : nullptr,
-                                       Config.RmsNormEps, B * T, C, main_stream);
+                                 nullptr, Config.RmsNormEps, B * T, C, main_stream);
         } else {
-            rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
+            rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w,
+                  nullptr, Config.RmsNormEps, B, T, C, main_stream);
         }
     }
 
@@ -452,7 +452,7 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
         forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
                          rs->CublasLtHandle, rs->Workspace,
                          B, T, C, 2 * D,
-                         rs->DeviceProp, false, false, main_stream);
+                         rs->DeviceProp, false, true, main_stream);
     }
 
     if(recompute_swiglu) {

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -137,7 +137,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         }
 
         auto weights = Parameters->get_block(l, main_stream);
-        trace_or_execute_cuda_graph([&](){_forward_block(l, weights, *rs);},
+        trace_or_execute_cuda_graph([&](){_forward_block(l, weights);},
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
     }
@@ -161,7 +161,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
     CUDA_CHECK(cudaEventRecord(rs->ForwardDone, main_stream));
 }
 
-void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights, LLamaRunState& run_state)
+void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
 {
     auto& rs = RunState;
     int l = layer;
@@ -367,7 +367,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         }
         auto& weights = Parameters->get_block(l, main_stream);
         // last layer changes topology, so for now just don't use graph
-        trace_or_execute_cuda_graph([&](){_backward_block(l, accumulate, weights, dw, *rs);}, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
+        trace_or_execute_cuda_graph([&](){_backward_block(l, accumulate, weights, dw);}, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
         Parameters->release_block(l, main_stream);
         Grads->notify_block(l, main_stream, comm);
     }
@@ -385,7 +385,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     CUDA_CHECK(cudaEventSynchronize(rs->TransferDone));
 }
 
-void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& d_weights, LLamaRunState& run_state) {
+void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& d_weights) {
     auto& rs = RunState;
     cudaStream_t main_stream = rs->MainStream;
     // convenience shortcuts, size_t instead of int so that pointer arithmetics don't overflow
@@ -421,7 +421,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     // backward the 2nd matmul of MLP
     backward_qmm(d_acts.DSwiGLU, d_weights.MLP_Down_w, std::nullopt, d_acts.DResFFN, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
-                       accumulate, run_state, B, T, D, C, reuse_swiglu, true, main_stream);
+                       accumulate, *rs, B, T, D, C, reuse_swiglu, true, main_stream);
 
     swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
 
@@ -430,7 +430,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     }
 
     backward_qmm(d_acts.DLN2, d_weights.MLP_Up_w, std::nullopt, d_acts.DMlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
-                       accumulate, run_state, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, true, main_stream);
+                       accumulate, *rs, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, true, main_stream);
 
     // rmsnorm backward does += to the dresidual, so it correctly accumulates grad from the MLP block above
     rmsnorm_backward(d_acts.DResAtt.Value, d_weights.LN2_w, rs->RMSNormScratch, d_acts.DResFFN.Value, d_acts.DLN2,
@@ -460,13 +460,13 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     }
 
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
-                       accumulate, run_state, B, T, C, C, false, true, main_stream);
+                       accumulate, *rs, B, T, C, C, false, true, main_stream);
 
     attention_backward_cudnn(d_acts.DRope, acts.LSE, acts.Att.Value, d_acts.DAttY, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
     rope_backward(d_acts.DQKV.Value, d_acts.DRope, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
 
     backward_qmm(d_acts.DLN1, d_weights.Attn_QKV_w, d_weights.Attn_QKV_b, d_acts.DQKV, acts.LN1, weights.Attn_QKV_w, rs->MatmulBiasScratch,
-                       accumulate, run_state, B, T, C, Config.qkv_channels(), !recompute_ln1, false, main_stream);
+                       accumulate, *rs, B, T, C, Config.qkv_channels(), !recompute_ln1, false, main_stream);
 
     if(layer > 0) {
         auto& prev_dacts = rs->DActs.at(layer - 1);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -385,6 +385,70 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     CUDA_CHECK(cudaEventSynchronize(rs->TransferDone));
 }
 
+void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights) {
+    auto& rs = RunState;
+    cudaStream_t main_stream = rs->MainStream;
+    // convenience shortcuts, size_t instead of int so that pointer arithmetics don't overflow
+    long B = rs->Inputs.Sizes[0];
+    long T = rs->Inputs.Sizes[1];
+    const size_t C = Config.HiddenSize;
+    long D = Config.IntermediateSize;
+    long Hq = Config.NumQueryHeads;
+    long Hkv = Config.NumKeyValHeads;
+    long Hs = Config.head_size();
+
+    auto& acts = rs->Acts[layer];
+
+    // Figure out which parts we need to recompute
+    bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
+    bool recompute_ln2 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeFFN;
+    bool recompute_qkv = rs->Options.RecomputeQKV || rs->Options.RecomputeAtt;
+    bool recompute_swiglu = rs->Options.RecomputeSwiGLu || rs->Options.RecomputeFFN;
+
+    // Attention block
+    if(recompute_ln1) {
+        Tensor& residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
+        rmsnorm_forward(acts.LN1.Value, acts.LN1_Rstd, residual, weights.LN1_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
+    }
+
+    if (recompute_qkv) {
+        // two scenarios: 1) we do not recompute the RMSnorm; then, we _will_ overwrite the full-precision copy of acts.LN1,
+        //                   but _can_ reuse the quantized version
+        //                2) we recompute RMSNorm; then, acts.LN1 will be correct, but its quantized version will not, so
+        //                   we have to re-quantize (TODO but we could reuse the absmax)
+        forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
+                     rs->CublasLtHandle, rs->Workspace,
+                     B, T, C, Config.qkv_channels(),
+                     rs->DeviceProp, !recompute_ln1, false, main_stream);
+        rope_forward(acts.Rope, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
+    }
+
+    if (rs->Options.RecomputeAtt) {
+        attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
+        // AttO not needed in backward pass :)
+    }
+
+    // Feed-forward block
+    if(recompute_ln2) {
+        rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
+    }
+
+    if(rs->Options.RecomputeFFN) {
+        forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
+                         rs->CublasLtHandle, rs->Workspace,
+                         B, T, C, 2 * D,
+                         rs->DeviceProp, false, false, main_stream);
+    }
+
+    if(recompute_swiglu) {
+        if (acts.SwiGLu.Quant.has_value() && acts.SwiGLu.Quant->DType == ETensorDType::FP8_E4M3) {
+            swiglu_forward_quant(acts.SwiGLu.Quant.value(), acts.MlpUp, acts.SwiGLu.Quant->Scales, B, T, D, main_stream);
+        } else {
+            swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, nullptr, B, T, D, main_stream);
+        }
+    }
+}
+
 void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& d_weights) {
     auto& rs = RunState;
     cudaStream_t main_stream = rs->MainStream;
@@ -400,21 +464,14 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     auto& acts = rs->Acts[layer];
     auto& d_acts = rs->DActs.at(layer);
 
+    _recompute_block(layer, weights);
+
     bool reuse_swiglu = true;
-    if(rs->Options.RecomputeFFN) {
-        rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
-        forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
-                         rs->CublasLtHandle, rs->Workspace,
-                         B, T, C, 2 * D,
-                         rs->DeviceProp, false, false, main_stream);
-    }
 
     if(rs->Options.RecomputeSwiGLu || rs->Options.RecomputeFFN) {
         if (acts.SwiGLu.Quant.has_value() && acts.SwiGLu.Quant->DType == ETensorDType::FP8_E4M3) {
-            swiglu_forward_quant(acts.SwiGLu.Quant.value(), acts.MlpUp, acts.SwiGLu.Quant->Scales, B, T, D, main_stream);
             reuse_swiglu = true;
         } else {
-            swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, nullptr, B, T, D, main_stream);
             reuse_swiglu = false;
         }
     }
@@ -425,10 +482,6 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
 
-    if(rs->Options.RecomputeRMSNorm && !rs->Options.RecomputeFFN) {
-        rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
-    }
-
     backward_qmm(d_acts.DLN2, d_weights.MLP_Up_w, std::nullopt, d_acts.DMlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
                        accumulate, *rs, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, true, main_stream);
 
@@ -437,28 +490,6 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
                      acts.ResidualAtt, weights.LN2_w, acts.LN2_Rstd, quant_abs_max_ptr(d_acts.DResAtt), B, T, C, rs->DeviceProp, main_stream);
 
     bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
-    if(recompute_ln1) {
-        Tensor& residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
-        rmsnorm_forward(acts.LN1.Value, acts.LN1_Rstd, residual, weights.LN1_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
-    }
-
-    if (rs->Options.RecomputeQKV || rs->Options.RecomputeAtt) {
-        // two scenarios: 1) we do not recompute the RMSnorm; then, we _will_ overwrite the full-precision copy of acts.LN1,
-        //                   but _can_ reuse the quantized version
-        //                2) we recompute RMSNorm; then, acts.LN1 will be correct, but its quantized version will not, so
-        //                   we have to re-quantize (TODO but we could reuse the absmax)
-        forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
-                     rs->CublasLtHandle, rs->Workspace,
-                     B, T, C, Config.qkv_channels(),
-                     rs->DeviceProp, !recompute_ln1, false, main_stream);
-        rope_forward(acts.Rope, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
-
-        if (rs->Options.RecomputeAtt) {
-            attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
-            // AttO not needed in backward pass :)
-        }
-    }
-
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
                        accumulate, *rs, B, T, C, C, false, true, main_stream);
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -12,8 +12,6 @@
 #include "llama_weights.h"
 #include "utilities/comm.h"
 
-constexpr const int QWEN2_NUM_LINEAR_OPS = 4;
-
 LLamaModel::LLamaModel(LLamaConfig config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc) :
         Config(config), Options(options), Allocator(alloc ? alloc : std::make_shared<TensorAllocator>())
 {
@@ -241,11 +239,11 @@ float LLamaModel::validate(Tensor inputs, Tensor targets, NCCLCommunicator& comm
 }
 
 void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
-                        QuantizableTensor& dout, QuantizableTensor& inp, Tensor& weight, std::optional<Tensor> bias_buffer,
-                        bool accumulate_gradient,
-                        LLamaRunState& rs,
-                        int B, int T, int C, int OC,
-                        bool reuse_inp, bool dout_has_absmax, cudaStream_t stream) {
+                  QuantizableTensor& dout, QuantizableTensor& inp, Tensor& weight, std::optional<Tensor> bias_buffer,
+                  bool accumulate_gradient,
+                  LLamaRunState& rs,
+                  int B, int T, int C, int OC,
+                  bool reuse_inp, bool dout_has_absmax, cudaStream_t stream) {
     if (weight.DType == inp.Value.DType) {
         matmul_backward(dinp, dweight, dbias, dout.Value, inp.Value, weight, bias_buffer, nullptr, nullptr, accumulate_gradient,
                         rs.CublasLtHandle, rs.Workspace, B, T, C, OC, rs.DeviceProp, stream);
@@ -456,7 +454,7 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
     }
 
     if(recompute_swiglu) {
-        if (acts.SwiGLu.Quant.has_value() && acts.SwiGLu.Quant->DType == ETensorDType::FP8_E4M3) {
+        if (acts.SwiGLu.Quant.has_value()) {
             swiglu_forward_quant(acts.SwiGLu.Quant.value(), acts.MlpUp, acts.SwiGLu.Quant->Scales, B, T, D, main_stream);
         } else {
             swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, nullptr, B, T, D, main_stream);
@@ -481,24 +479,15 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     _recompute_block(layer, weights);
 
-    bool reuse_swiglu = true;
-
-    if(rs->Options.RecomputeSwiGLu || rs->Options.RecomputeFFN) {
-        if (acts.SwiGLu.Quant.has_value() && acts.SwiGLu.Quant->DType == ETensorDType::FP8_E4M3) {
-            reuse_swiglu = true;
-        } else {
-            reuse_swiglu = false;
-        }
-    }
-
     // backward the 2nd matmul of MLP
+    // note that _recompute_block guarantees that if SwiGLu is already quantized (if necessary)
     backward_qmm(d_acts.DSwiGLU, d_weights.MLP_Down_w, std::nullopt, d_acts.DResFFN, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
-                       accumulate, *rs, B, T, D, C, reuse_swiglu, true, main_stream);
+                 accumulate, *rs, B, T, D, C, true, true, main_stream);
 
     swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
 
     backward_qmm(d_acts.DLN2, d_weights.MLP_Up_w, std::nullopt, d_acts.DMlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
-                       accumulate, *rs, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, true, main_stream);
+                 accumulate, *rs, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, true, main_stream);
 
     // rmsnorm backward does += to the dresidual, so it correctly accumulates grad from the MLP block above
     rmsnorm_backward(d_acts.DResAtt.Value, d_weights.LN2_w, rs->RMSNormScratch, d_acts.DResFFN.Value, d_acts.DLN2,
@@ -506,7 +495,7 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
 
     bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
-                       accumulate, *rs, B, T, C, C, false, true, main_stream);
+                 accumulate, *rs, B, T, C, C, false, true, main_stream);
 
     attention_backward_cudnn(d_acts.DRope, acts.LSE, acts.Att.Value, d_acts.DAttY, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
     rope_backward(d_acts.DQKV.Value, d_acts.DRope, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -398,12 +398,13 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
     long Hs = Config.head_size();
 
     auto& acts = rs->Acts[layer];
+    auto& opt = rs->Options;
 
     // Figure out which parts we need to recompute
-    bool recompute_ln1 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeAtt;
-    bool recompute_ln2 = rs->Options.RecomputeRMSNorm || rs->Options.RecomputeFFN;
-    bool recompute_qkv = rs->Options.RecomputeQKV || rs->Options.RecomputeAtt;
-    bool recompute_swiglu = rs->Options.RecomputeSwiGLu || rs->Options.RecomputeFFN;
+    bool recompute_ln1 = opt.RecomputeRMSNorm || opt.RecomputeAtt || opt.RecomputeBlock;
+    bool recompute_ln2 = opt.RecomputeRMSNorm || opt.RecomputeFFN || opt.RecomputeBlock;
+    bool recompute_qkv = opt.RecomputeQKV || opt.RecomputeAtt || opt.RecomputeBlock;
+    bool recompute_swiglu = opt.RecomputeSwiGLu || opt.RecomputeFFN || opt.RecomputeBlock;
 
     // Attention block
     if(recompute_ln1) {
@@ -423,17 +424,31 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
         rope_forward(acts.Rope, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
     }
 
-    if (rs->Options.RecomputeAtt) {
+    if (opt.RecomputeAtt) {
         attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.Rope, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
-        // AttO not needed in backward pass :)
+        // AttO not needed in backward pass; but if we want to recompute the entire transformer block, we need its output
+        // to recompute the FFN part
+        if (opt.RecomputeBlock) {
+            forward_qmm(acts.AttO, acts.Att, weights.Attn_Out_w, std::nullopt,
+                         rs->CublasLtHandle, rs->Workspace,
+                         B, T, C, C,
+                         rs->DeviceProp, false, false, main_stream);
+        }
     }
 
     // Feed-forward block
     if(recompute_ln2) {
-        rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
+        if (opt.RecomputeBlock) {
+            Tensor residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
+            fused_residual_rmsnorm_forward(acts.ResidualAtt, acts.LN2.Value, acts.LN2_Rstd, residual, acts.AttO, weights.LN2_w,
+                                       acts.LN2.Quant.has_value() ? acts.LN2.Quant->Scales : nullptr,
+                                       Config.RmsNormEps, B * T, C, main_stream);
+        } else {
+            rmsnorm_forward(acts.LN2.Value, acts.LN2_Rstd, acts.ResidualAtt, weights.LN2_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
+        }
     }
 
-    if(rs->Options.RecomputeFFN) {
+    if(opt.RecomputeFFN) {
         forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
                          rs->CublasLtHandle, rs->Workspace,
                          B, T, C, 2 * D,

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -98,8 +98,8 @@ protected:
     void _calculate_gradient_norm(NCCLCommunicator& comm, float grad_clip);
     void _reduce_loss(LLamaRunState& acts, NCCLCommunicator& comm, int B, int T);
 
-    void _forward_block(int layer, sLLamaBlockWeights<Tensor>& weights, LLamaRunState& run_state);
-    void _backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& grads, LLamaRunState& run_state);
+    void _forward_block(int layer, sLLamaBlockWeights<Tensor>& weights);
+    void _backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& grads);
 private:
     LLamaConfig Config;
     LLamaOptions Options;

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -23,6 +23,7 @@ struct LLamaOptions {
     bool RecomputeFFN = false;
     bool RecomputeQKV = false;
     bool RecomputeAtt = false;
+    bool RecomputeBlock = false;
     bool UseCudaGraphs = false;
 
     bool OffloadMaster = false;

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -99,6 +99,7 @@ protected:
     void _reduce_loss(LLamaRunState& acts, NCCLCommunicator& comm, int B, int T);
 
     void _forward_block(int layer, sLLamaBlockWeights<Tensor>& weights);
+    void _recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights);
     void _backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& grads);
 private:
     LLamaConfig Config;

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -62,6 +62,7 @@ private:
     Tensor tQKVBuffer;
     Tensor tAttBuffer;
     Tensor tLN1Buffer;
+    Tensor tResAttBuffer;
 };
 
 Tensor RunStateBuilder::generate_frequencies() {
@@ -88,7 +89,7 @@ LLamaRunState::LayerActivations RunStateBuilder::allocate_basic_fwd_tensors(Tens
     Tensor ln2_v = allocate_or_reuse(reuse_ln_buffer || Options.RecomputeFFN, lnf, Config.DType, "ln2", B, T, C);
 
     Tensor qkv = allocate_or_reuse(Options.RecomputeQKV, tQKVBuffer, Config.DType, "qkv", B, T, Config.qkv_channels());
-    Tensor res_att = allocate(Config.DType, "res_att", B, T, C);
+    Tensor res_att = allocate_or_reuse(Options.RecomputeBlock, tResAttBuffer, Config.DType, "res_att", B, T, C);
     Tensor res_ffn = allocate(Config.DType, "res_ffn", B, T, C);
     Tensor lse = allocate(ETensorDType::FP32, "lse", B, T, Config.NumQueryHeads);
     Tensor att_v = allocate_or_reuse(Options.RecomputeAtt, tAttBuffer, Config.DType, "att_v", B, T, C);

--- a/src/testing/recompute.cpp
+++ b/src/testing/recompute.cpp
@@ -85,6 +85,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_flag("--recompute-ffn", Options.RecomputeFFN, "Recompute the feed-forward block during the backward pass to save activation memory");
     app.add_flag("--recompute-qkv", Options.RecomputeQKV, "Recompute the qkv projections during the backward pass");
     app.add_flag("--recompute-att", Options.RecomputeAtt, "Recompute the attention block during the backward pass");
+    app.add_flag("--recompute-block", Options.RecomputeBlock, "Recompute the entire transformer block");
     app.add_flag("--use-cuda-graphs,!--no-use-cuda-graphs", Options.UseCudaGraphs, "Enable/disable use of cuda graphs");
 
     // These should normally stay at their default values

--- a/train.cpp
+++ b/train.cpp
@@ -135,6 +135,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_flag("--recompute-ffn", Options.RecomputeFFN, "Recompute the feed-forward block during the backward pass to save activation memory");
     app.add_flag("--recompute-qkv", Options.RecomputeQKV, "Recompute the qkv projections during the backward pass");
     app.add_flag("--recompute-att", Options.RecomputeAtt, "Recompute the attention block during the backward pass");
+    app.add_flag("--recompute-block", Options.RecomputeBlock, "Recompute the entire transformer block");
     app.add_flag("--use-cuda-graphs,!--no-use-cuda-graphs", Options.UseCudaGraphs, "Enable/disable use of cuda graphs");
     auto zero = app.add_option("--zero-level", ZeroLevel, "Zero redundancy level: 1 - sharded optimizer; 2 - sharded gradients; 3 - sharded weights");
     app.add_flag("--offload-master", Options.OffloadMaster, "Store master weights in pinned host memory.");
@@ -179,6 +180,12 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
         break;
     default:
         std::cerr << "Warning: Invalid ZeRO-level " << ZeroLevel << std::endl;
+    }
+
+    if (Options.RecomputeBlock) {
+        Options.RecomputeAtt = true;
+        Options.RecomputeFFN = true;
+        Options.RecomputeRMSNorm = true;
     }
 
     if (Options.RecomputeAtt) {
@@ -244,6 +251,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
         {"recompute-ffn",      Options.RecomputeFFN},
         {"recompute-qkv",      Options.RecomputeQKV},
         {"recompute-att",      Options.RecomputeAtt},
+        {"recompute-block",    Options.RecomputeBlock},
         {"offload-master",     Options.OffloadMaster},
         {"offload-quants",     Options.OffloadQuants},
         {"offload-opt-m",      Options.OffloadOptM},


### PR DESCRIPTION
This requires one more matrix multiplication on the backward pass, but halves the amount of activation memory that needs to be kept compared to the current setting.

This allows us to achieve reasonable mfu even with the 14B model on 4x4090:

Old:
| Model        | nGPU | DType | Batch | TPS  | SOL | TTB   |
|--------------|------|-------|-------|------|-----|-------|
| Qwen2.5-14B⁶ | 4 | fp8  | 4 | 3.2k | 22% | 87h  |
| Qwen2.5-14B⁷ | 4 | bf16 | 4 | 2.5k | 33% | 111h |

New:
| Model        | nGPU | DType | Batch | TPS  | SOL | TTB   |
|--------------|------|-------|-------|------|-----|-------|
| Qwen2.5-14B⁸ | 4 | fp8  | 8 | 6.0k | 42% | 47h |
| Qwen2.5-14B⁹ | 4 | bf16 | 8 | 4.5k | 58% | 62h |

