### PR TITLE
Matmul cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,13 +138,14 @@ add_library(libllmq SHARED
 
         src/kernels/kernels.cpp
         src/kernels/encoder.cu
-        src/kernels/matmul.cu
+        src/kernels/matmul.cpp
         src/kernels/swiglu.cu
         src/kernels/rope.cu
         src/kernels/rmsnorm.cu
         src/kernels/cudnn_att.cpp
         src/kernels/quant.cu
         src/kernels/global_norm.cu
+        src/kernels/bias.cu
         src/kernels/adamw.cu
         src/kernels/attention.cu
         src/kernels/fused_classifier.cu

--- a/src/kernels/bias.cu
+++ b/src/kernels/bias.cu
@@ -1,0 +1,180 @@
+#include "utilities/vec.cuh"
+#include "utilities/utils.h"
+#include "utilities/dtype.h"
+
+#include <type_traits>
+#include <cassert>
+
+
+template<class floatO, class floatB>
+__global__ void add_bias_kernel(floatO* out, const floatB* bias, int B, int T, int OC) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    for (int i = idx; i < B * T * OC; i += stride) {
+        int col = i % OC;
+        out[i] += bias[col];
+    }
+}
+
+template<class floatO, class floatB>
+void add_bias_impl(floatO* out, const floatB* bias, int B, int T, int OC, cudaStream_t stream) {
+    int block_size = 256;
+    int grid_size = div_ceil(OC * B * T, block_size);
+    add_bias_kernel<<<grid_size, block_size, 0, stream>>>(out, bias, B, T, OC);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void add_bias(float* out, const float* bias, int B, int T, int OC, cudaStream_t stream) {
+    add_bias_impl(out, bias, B, T, OC, stream);
+}
+
+void add_bias(nv_bfloat16* out, const nv_bfloat16* bias, int B, int T, int OC, cudaStream_t stream) {
+    add_bias_impl(out, bias, B, T, OC, stream);
+}
+
+template<typename floatX, typename OutFloat, bool UseAuxBuffer>
+__global__ void matmul_backward_bias_kernel(OutFloat* dbias, const floatX* dout, const float* abs_max, int B, int T, int OC,
+                                            std::bool_constant<UseAuxBuffer>) {
+    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
+    using f128 = GenericVector<float, 16/sizeof(float)>;
+    constexpr const int bdx = 4;
+    constexpr const int bdy = 32 / bdx;
+    assert(blockDim.x == bdx);
+    assert(blockDim.y == bdy);
+
+    int warp_d = (int)threadIdx.x;
+    int warp_c = (int)threadIdx.y;
+    int block_d = (int)threadIdx.z;
+
+    const int OC_per_warp = bdy * x128::size;  // 64 at BF16
+
+    int local_oc = warp_c * x128::size;
+    int global_oc = blockIdx.x * OC_per_warp + local_oc;
+
+    int local_bt = warp_d + bdx * block_d;
+    int bt_per_block = bdx * blockDim.z;
+
+    float accumulators[x128::size];
+    for (int k = 0; k < x128::size; k++) {
+        accumulators[k] = 0.0f;
+    }
+
+    if(global_oc < OC) {
+        // sum up over all bt within registers
+        for (int idx = blockIdx.y * bt_per_block + local_bt; idx < B * T; idx += gridDim.y * bt_per_block) {
+            x128 packed_dout = x128::load(dout + global_oc + idx*OC);
+            for (int k = 0; k < x128::size; k++) {
+                accumulators[k] += (float)packed_dout[k];
+            }
+        }
+    }
+
+    __shared__ float sub_results[x128::size][32][bdy];
+
+    // reduce within-warp results
+    for (int k = 0; k < x128::size; k++) {
+        float v = accumulators[k];
+        v += __shfl_down_sync(0xffffffff, v, 1, 4);
+        v += __shfl_down_sync(0xffffffff, v, 2, 4);
+        if(warp_d == 0) {
+            sub_results[k][block_d][warp_c] = v;
+        }
+    }
+    __syncthreads();
+
+    // block-wide reductions
+    for (int k = block_d; k < x128::size; k += blockDim.z) {
+        float a = 0.f;
+        for (int r = warp_d; r < blockDim.z; r += bdx) {
+            float v = sub_results[k][r][warp_c];
+            v += __shfl_down_sync(0xffffffff, v, 1, 4);
+            v += __shfl_down_sync(0xffffffff, v, 2, 4);
+            a += v;
+        }
+        if(warp_d == 0 && global_oc < OC) {
+            if(abs_max != nullptr) {
+                a *= *abs_max;
+                if constexpr (std::is_same_v<floatX, __nv_fp8_e4m3>) {
+                    a /= 448.f;
+                }
+            }
+            if constexpr (!UseAuxBuffer) {
+                dbias[global_oc + k] = (OutFloat)(a + (float)dbias[global_oc + k]);
+            } else {
+                dbias[global_oc + k + blockIdx.y * OC] = a;
+            }
+        }
+    }
+}
+
+template<class floatX>
+__global__ void reduce_add_sum_kernel(floatX* dst, const float* src, size_t n, size_t m) {
+    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
+    using f128 = GenericVector<float, 16/sizeof(float)>;
+    const size_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * f128::size;
+    assert(n % x128::size == 0);
+    if (idx < n) {
+        f128 acc;
+        for(int k = 0; k < f128::size; ++k) {
+            acc[k] = 0.f;
+        }
+
+        for(int l = 0; l < m; ++l) {
+            f128 s = f128::load(src + idx + n * l);
+            for(int k = 0; k < f128::size; ++k) {
+                acc[k] += s[k];
+            }
+        }
+        for(int k = 0; k < f128::size; ++k) {
+            dst[idx + k] = (floatX) ((float)dst[idx + k] + acc[k]);
+        }
+    }
+}
+
+int get_bias_backward_scratch_size(ETensorDType dtype, int OC, const cudaDeviceProp& dp) {
+    const int block_size = dp.maxThreadsPerMultiProcessor == 1536 ? 768 : 1024;
+    const int OC_per_warp = 8 * ( 16 / get_dtype_size(dtype) ); // 64 at BF16
+    const int grid_size_x = div_ceil(OC, OC_per_warp); // e.g. 12 horizontal blocks for 768 OCs at BF16
+    const int grid_size_y = max(1, block_size * dp.multiProcessorCount / (block_size * grid_size_x)); // full GPU!
+    return grid_size_y * OC * sizeof(float);
+}
+
+template<class floatX, class FloatY>
+void backward_bias_imp(floatX* dbias, const FloatY* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
+    // Each warp is responsible for 8 * "x128::size" = 64 OCs at BF16 (OC must be a multiple of 64!)
+    // Block size is 1024 | 768 threads (32|24 warps) and we reduce those values into 1 at the end
+    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
+    using f128 = GenericVector<float, 16/sizeof(float)>;
+
+    const int block_size = dp.maxThreadsPerMultiProcessor == 1536 ? 768 : 1024;
+
+    dim3 block_dim = {4, 8, (unsigned)block_size/32};
+    const int OC_per_warp = block_dim.y * x128::size; // 64 at BF16
+    const int grid_size_x = div_ceil(OC, OC_per_warp); // e.g. 12 horizontal blocks for 768 OCs at BF16
+    const int grid_size_y = max(1, block_size * dp.multiProcessorCount / (block_size * grid_size_x)); // full GPU!
+
+    // If we have enough OC that we don't need cross-block reductions, we can skip the bias_buffer accumulation
+    // and write results directly to the output.
+    if(grid_size_y == 1) {
+        matmul_backward_bias_kernel<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias, dout, dout_abs_max, B, T, OC, std::bool_constant<false>());
+        CUDA_CHECK(cudaGetLastError());
+    } else {
+        // kernel 9 overwrites temp buffer, so no need to memset
+        matmul_backward_bias_kernel<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias_buffer, dout, dout_abs_max, B, T, OC, std::bool_constant<true>());
+        CUDA_CHECK(cudaGetLastError());
+        reduce_add_sum_kernel<<<div_ceil((size_t)OC, 256 * f128::size), 256, 0, stream>>>(dbias, dbias_buffer, OC, grid_size_y);
+        CUDA_CHECK(cudaGetLastError());
+    }
+}
+
+void backward_bias(float* dbias, const float* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream)  {
+    backward_bias_imp(dbias, dout, dout_abs_max, dbias_buffer, B, T, OC, dp, stream);
+}
+
+void backward_bias(nv_bfloat16* dbias, const nv_bfloat16* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream)  {
+    backward_bias_imp(dbias, dout, dout_abs_max, dbias_buffer, B, T, OC, dp, stream);
+}
+
+void backward_bias(nv_bfloat16* dbias, const __nv_fp8_e4m3* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream)  {
+    backward_bias_imp(dbias, dout, dout_abs_max, dbias_buffer, B, T, OC, dp, stream);
+}

--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -248,3 +248,35 @@ void fill_constant(Tensor& dest, float value, std::size_t count, cudaStream_t st
         throw std::logic_error("fill_constant: unsupported dtype");
     }
 }
+
+void matmul(Tensor& c, const Tensor& a, const Tensor& b, std::optional<Tensor> bias, const float* scale,
+            cublasLtHandle_t handle, Tensor& workspace,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    std::byte* ws = workspace.get<std::byte>();
+    std::size_t ws_size = workspace.bytes();
+    if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::FP32) {
+        float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
+        matmul(c.get<float>(), a.get<float>(), b.get<float>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+    } else if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::BF16) {
+        float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
+        matmul(c.get<float>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+    } else if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::FP8_E4M3) {
+        if(bias.has_value()) {
+            if(bias.value().DType == ETensorDType::BF16) {
+                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<nv_bfloat16>(), scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+            } else {
+                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<float>(), scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+            }
+        } else {
+            matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), (nv_bfloat16*)nullptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+        }
+    } else if(c.DType == ETensorDType::BF16 && a.DType == ETensorDType::FP8_E4M3) {
+        nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
+        matmul(c.get<nv_bfloat16>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+    } else if(c.DType == ETensorDType::BF16) {
+        nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
+        matmul(c.get<nv_bfloat16>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+    } else {
+        throw std::logic_error("matmul_forward: invalid DType combination");
+    }
+}

--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -251,31 +251,31 @@ void fill_constant(Tensor& dest, float value, std::size_t count, cudaStream_t st
 
 void matmul(Tensor& c, const Tensor& a, const Tensor& b, std::optional<Tensor> bias, const float* scale,
             cublasLtHandle_t handle, Tensor& workspace,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
     std::byte* ws = workspace.get<std::byte>();
     std::size_t ws_size = workspace.bytes();
     if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::FP32) {
         float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
-        matmul(c.get<float>(), a.get<float>(), b.get<float>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+        matmul(c.get<float>(), a.get<float>(), b.get<float>(), bias_ptr, scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
     } else if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::BF16) {
         float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
-        matmul(c.get<float>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+        matmul(c.get<float>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
     } else if(c.DType == ETensorDType::FP32 && a.DType == ETensorDType::FP8_E4M3) {
         if(bias.has_value()) {
             if(bias.value().DType == ETensorDType::BF16) {
-                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<nv_bfloat16>(), scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<nv_bfloat16>(), scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
             } else {
-                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<float>(), scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+                matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias->get<float>(), scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
             }
         } else {
-            matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), (nv_bfloat16*)nullptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+            matmul(c.get<float>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), (nv_bfloat16*)nullptr, scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
         }
     } else if(c.DType == ETensorDType::BF16 && a.DType == ETensorDType::FP8_E4M3) {
         nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
-        matmul(c.get<nv_bfloat16>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+        matmul(c.get<nv_bfloat16>(), a.get<__nv_fp8_e4m3>(), b.get<__nv_fp8_e4m3>(), bias_ptr, scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
     } else if(c.DType == ETensorDType::BF16) {
         nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
-        matmul(c.get<nv_bfloat16>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, mode, accumulate, stream);
+        matmul(c.get<nv_bfloat16>(), a.get<nv_bfloat16>(), b.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, M, N, K, mode, accumulate, stream);
     } else {
         throw std::logic_error("matmul_forward: invalid DType combination");
     }

--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -280,3 +280,15 @@ void matmul(Tensor& c, const Tensor& a, const Tensor& b, std::optional<Tensor> b
         throw std::logic_error("matmul_forward: invalid DType combination");
     }
 }
+
+void backward_bias(Tensor& dbias, const Tensor& dout, const float* dout_abs_max, Tensor& dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
+    if(dbias.DType == ETensorDType::FP32 && dout.DType == ETensorDType::FP32) {
+        backward_bias(dbias.get<float>(), dout.get<float>(), dout_abs_max, dbias_buffer.get<float>(), B, T, OC, dp, stream);
+    } else if(dbias.DType == ETensorDType::BF16 && dout.DType == ETensorDType::BF16) {
+        backward_bias(dbias.get<nv_bfloat16>(), dout.get<nv_bfloat16>(), dout_abs_max, dbias_buffer.get<float>(), B, T, OC, dp, stream);
+    }  else if(dbias.DType == ETensorDType::BF16 && dout.DType == ETensorDType::FP8_E4M3) {
+        backward_bias(dbias.get<nv_bfloat16>(), dout.get<__nv_fp8_e4m3>(), dout_abs_max, dbias_buffer.get<float>(), B, T, OC, dp, stream);
+    } else {
+        throw std::logic_error("backward_bias: unsupported dtype");
+    }
+}

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -18,6 +18,9 @@ typedef struct cublasLtContext* cublasLtHandle_t;
 struct Tensor;
 enum class ETensorDType: int;
 
+enum class EMMTranspose { TT, TN, NT, NN };
+
+
 void encoder_forward(float* out, const int* inp, const float* wte, const float* wpe, int B, int T, int C, int V, cudaStream_t stream);
 void encoder_forward(nv_bfloat16* out, const int* inp, const nv_bfloat16* wte, const nv_bfloat16* wpe, int B, int T, int C, int V, cudaStream_t stream);
 void encoder_forward(Tensor& out, const Tensor& inp, const Tensor& wte, std::optional<Tensor> wpe, int B, int T, int C, int V, cudaStream_t stream);
@@ -54,15 +57,33 @@ void fused_residual_rmsnorm_forward(nv_bfloat16* residual, nv_bfloat16* normed, 
 void fused_residual_rmsnorm_forward(Tensor& residual, Tensor& normed, Tensor& rrms, const Tensor& inp1, const Tensor& inp2, const Tensor& weight, float* abs_max_ptr,
                                     float epsilon, int N, int C, cudaStream_t stream);
 
-void matmul_forward(float* out, const float* inp, const float* weight, const float* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream);
-void matmul_forward(nv_bfloat16* out, const nv_bfloat16* inp, const nv_bfloat16* weight, const nv_bfloat16* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream);
-void matmul_forward(Tensor& out, const Tensor& inp, const Tensor& weight, std::optional<Tensor> bias, const float* scale,
-                    cublasLtHandle_t handle, Tensor& workspace,
-                    int B, int T, int C, int OC, cudaStream_t stream);
+void matmul(float* c, const float* a, const float* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(float* c, const nv_bfloat16* a, const nv_bfloat16* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(nv_bfloat16* c, const nv_bfloat16* a, const nv_bfloat16* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(nv_bfloat16* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+
+void matmul(Tensor& c, const Tensor& a, const Tensor& b, std::optional<Tensor> bias, const float* scale,
+            cublasLtHandle_t handle, Tensor& workspace,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void add_bias(float* out, const float* bias, int B, int T, int OC, cudaStream_t stream);
 void add_bias(nv_bfloat16* out, const nv_bfloat16* bias, int B, int T, int OC, cudaStream_t stream);

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -64,7 +64,14 @@ void matmul_forward(Tensor& out, const Tensor& inp, const Tensor& weight, std::o
                     cublasLtHandle_t handle, Tensor& workspace,
                     int B, int T, int C, int OC, cudaStream_t stream);
 
+void add_bias(float* out, const float* bias, int B, int T, int OC, cudaStream_t stream);
+void add_bias(nv_bfloat16* out, const nv_bfloat16* bias, int B, int T, int OC, cudaStream_t stream);
 int get_bias_backward_scratch_size(ETensorDType dtype, int OC, const cudaDeviceProp& dp);
+void backward_bias(float* dbias, const float* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
+void backward_bias(nv_bfloat16* dbias, const nv_bfloat16* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
+void backward_bias(nv_bfloat16* dbias, const __nv_fp8_e4m3* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
+
+
 void matmul_backward(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,
                      const Tensor& dout, const Tensor& inp, const Tensor& weight,
                      std::optional<Tensor> dbias_buffer,

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -94,20 +94,6 @@ void backward_bias(nv_bfloat16* dbias, const __nv_fp8_e4m3* dout, const float* d
 void backward_bias(Tensor& dbias, const Tensor& dout, const float* dout_abs_max, Tensor& dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
 
 
-void matmul_backward(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,
-                     const Tensor& dout, const Tensor& inp, const Tensor& weight,
-                     std::optional<Tensor> dbias_buffer,
-                     const float* dinp_scale, const float* dweight_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, Tensor& workspace,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
-void matmul_backward_fp8(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,
-                     const Tensor& dout, const Tensor& dout_t, const Tensor& inp, const Tensor& weight,
-                     std::optional<Tensor> dbias_buffer, const float* dinp_scale, const float* dweight_scale, const float* dout_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, Tensor& workspace,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
-
 void precompute_freqs_cis(float *freqs_cis, int dim, int end, float theta);
 void precompute_freqs_cis(nv_bfloat16 *freqs_cis, int dim, int end, float theta);
 void rope_forward(float* out, const float* in, const float *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -59,31 +59,31 @@ void fused_residual_rmsnorm_forward(Tensor& residual, Tensor& normed, Tensor& rr
 
 void matmul(float* c, const float* a, const float* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(float* c, const nv_bfloat16* a, const nv_bfloat16* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(nv_bfloat16* c, const nv_bfloat16* a, const nv_bfloat16* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(nv_bfloat16* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void matmul(Tensor& c, const Tensor& a, const Tensor& b, std::optional<Tensor> bias, const float* scale,
             cublasLtHandle_t handle, Tensor& workspace,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream);
 
 void add_bias(float* out, const float* bias, int B, int T, int OC, cudaStream_t stream);
 void add_bias(nv_bfloat16* out, const nv_bfloat16* bias, int B, int T, int OC, cudaStream_t stream);

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -91,6 +91,7 @@ int get_bias_backward_scratch_size(ETensorDType dtype, int OC, const cudaDeviceP
 void backward_bias(float* dbias, const float* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
 void backward_bias(nv_bfloat16* dbias, const nv_bfloat16* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
 void backward_bias(nv_bfloat16* dbias, const __nv_fp8_e4m3* dout, const float* dout_abs_max, float* dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
+void backward_bias(Tensor& dbias, const Tensor& dout, const float* dout_abs_max, Tensor& dbias_buffer, int B, int T, int OC, const cudaDeviceProp& dp, cudaStream_t stream);
 
 
 void matmul_backward(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,

--- a/src/kernels/matmul.cpp
+++ b/src/kernels/matmul.cpp
@@ -63,7 +63,7 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
                      std::byte* workspace, std::size_t workspace_size,
                      int m, int n, int k, cudaStream_t stream, cublasLtHandle_t handle,
                      const float* scale=nullptr, bool transA=true, bool transB=false,
-                     bool accumulate=false, bool backward=false)
+                     bool accumulate=false)
 {
     bool has_bias = (bias != nullptr);
 
@@ -114,11 +114,9 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
                                                      &workspace_size, sizeof(workspace_size)));
 
     // setup epilogue and associated pointers for bias & gelu
-    cublasLtEpilogue_t epilogue;
+    cublasLtEpilogue_t epilogue = CUBLASLT_EPILOGUE_DEFAULT;
     if(has_bias){
-        epilogue = backward ? CUBLASLT_EPILOGUE_BGRADB : CUBLASLT_EPILOGUE_BIAS;
-    } else {
-        epilogue = CUBLASLT_EPILOGUE_DEFAULT;
+        epilogue = CUBLASLT_EPILOGUE_BIAS;
     }
     CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
 
@@ -178,61 +176,35 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
     CUDA_CHECK(cudaGetLastError());
 }
 
-template<class floatO, class floatB>
-__global__ void add_bias_kernel(floatO* out, const floatB* bias, int B, int T, int OC) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int stride = blockDim.x * gridDim.x;
-    for (int i = idx; i < B * T * OC; i += stride) {
-        int col = i % OC;
-        out[i] += bias[col];
-    }
-}
-
-template<class floatO, class floatB>
-void add_bias_impl(floatO* out, const floatB* bias, int B, int T, int OC, cudaStream_t stream) {
-    int block_size = 256;
-    int grid_size = div_ceil(OC * B * T, block_size);
-    add_bias_kernel<<<grid_size, block_size, 0, stream>>>(out, bias, B, T, OC);
-    CUDA_CHECK(cudaGetLastError());
-}
-
-void add_bias(float* out, const float* bias, int B, int T, int OC, cudaStream_t stream) {
-    add_bias_impl(out, bias, B, T, OC, stream);
-}
-
-void add_bias(nv_bfloat16* out, const nv_bfloat16* bias, int B, int T, int OC, cudaStream_t stream) {
-    add_bias_impl(out, bias, B, T, OC, stream);
-}
-
 // small wrapper around matmul_cublaslt for the forward pass (keeping historical order of arguments)
 void matmul_forward(float* out, const float* inp, const float* weight, const float* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, true, false, false);
 }
 
 void matmul_forward(float* out, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
 }
 
 void matmul_forward(float* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const float* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
 }
 
 void matmul_forward(float* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const nv_bfloat16* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
 }
 
 void matmul_forward(float* out, const std::int8_t* inp, const std::int8_t* weight, const float* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
     if(bias) {
         add_bias(out, bias, B, T, OC, stream);
     }
@@ -241,13 +213,13 @@ void matmul_forward(float* out, const std::int8_t* inp, const std::int8_t* weigh
 void matmul_forward(nv_bfloat16* out, const nv_bfloat16* inp, const nv_bfloat16* weight, const nv_bfloat16* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
 }
 
 void matmul_forward(nv_bfloat16* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const nv_bfloat16* bias, const float* scale,
                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                     int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false, false);
+    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
 }
 
 void matmul_forward(Tensor& out, const Tensor& inp, const Tensor& weight, std::optional<Tensor> bias, const float* scale,
@@ -286,115 +258,6 @@ void matmul_forward(Tensor& out, const Tensor& inp, const Tensor& weight, std::o
     }
 }
 
-
-template<typename floatX, typename OutFloat, bool UseAuxBuffer>
-__global__ void matmul_backward_bias_kernel9(OutFloat* dbias, const floatX* dout, const float* abs_max, int B, int T, int OC,
-                                             std::bool_constant<UseAuxBuffer>) {
-    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
-    using f128 = GenericVector<float, 16/sizeof(float)>;
-    constexpr const int bdx = 4;
-    constexpr const int bdy = 32 / bdx;
-    assert(blockDim.x == bdx);
-    assert(blockDim.y == bdy);
-
-    int warp_d = (int)threadIdx.x;
-    int warp_c = (int)threadIdx.y;
-    int block_d = (int)threadIdx.z;
-
-    const int OC_per_warp = bdy * x128::size;  // 64 at BF16
-
-    int local_oc = warp_c * x128::size;
-    int global_oc = blockIdx.x * OC_per_warp + local_oc;
-
-    int local_bt = warp_d + bdx * block_d;
-    int bt_per_block = bdx * blockDim.z;
-
-    float accumulators[x128::size];
-    for (int k = 0; k < x128::size; k++) {
-        accumulators[k] = 0.0f;
-    }
-
-    if(global_oc < OC) {
-        // sum up over all bt within registers
-        for (int idx = blockIdx.y * bt_per_block + local_bt; idx < B * T; idx += gridDim.y * bt_per_block) {
-            x128 packed_dout = x128::load(dout + global_oc + idx*OC);
-            for (int k = 0; k < x128::size; k++) {
-                accumulators[k] += (float)packed_dout[k];
-            }
-        }
-    }
-
-    __shared__ float sub_results[x128::size][32][bdy];
-
-    // reduce within-warp results
-    for (int k = 0; k < x128::size; k++) {
-        float v = accumulators[k];
-        v += __shfl_down_sync(0xffffffff, v, 1, 4);
-        v += __shfl_down_sync(0xffffffff, v, 2, 4);
-        if(warp_d == 0) {
-            sub_results[k][block_d][warp_c] = v;
-        }
-    }
-    __syncthreads();
-
-    // block-wide reductions
-    for (int k = block_d; k < x128::size; k += blockDim.z) {
-        float a = 0.f;
-        for (int r = warp_d; r < blockDim.z; r += bdx) {
-            float v = sub_results[k][r][warp_c];
-            v += __shfl_down_sync(0xffffffff, v, 1, 4);
-            v += __shfl_down_sync(0xffffffff, v, 2, 4);
-            a += v;
-        }
-        if(warp_d == 0 && global_oc < OC) {
-            if(abs_max != nullptr) {
-                a *= *abs_max;
-                if constexpr (std::is_same_v<floatX, __nv_fp8_e4m3>) {
-                    a /= 448.f;
-                }
-            }
-            if constexpr (!UseAuxBuffer) {
-                dbias[global_oc + k] = (OutFloat)(a + (float)dbias[global_oc + k]);
-            } else {
-                dbias[global_oc + k + blockIdx.y * OC] = a;
-            }
-        }
-    }
-}
-
-template<class floatX>
-__global__ void reduce_add_sum_kernel(floatX* dst, const float* src, size_t n, size_t m) {
-    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
-    using f128 = GenericVector<float, 16/sizeof(float)>;
-    const size_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * f128::size;
-    assert(n % x128::size == 0);
-    if (idx < n) {
-        f128 acc;
-        for(int k = 0; k < f128::size; ++k) {
-            acc[k] = 0.f;
-        }
-
-        for(int l = 0; l < m; ++l) {
-            f128 s = f128::load(src + idx + n * l);
-            for(int k = 0; k < f128::size; ++k) {
-                acc[k] += s[k];
-            }
-        }
-        for(int k = 0; k < f128::size; ++k) {
-            dst[idx + k] = (floatX) ((float)dst[idx + k] + acc[k]);
-        }
-    }
-}
-
-int get_bias_backward_scratch_size(ETensorDType dtype, int OC, const cudaDeviceProp& dp) {
-    const int block_size = dp.maxThreadsPerMultiProcessor == 1536 ? 768 : 1024;
-    const int OC_per_warp = 8 * ( 16 / get_dtype_size(dtype) ); // 64 at BF16
-    const int grid_size_x = div_ceil(OC, OC_per_warp); // e.g. 12 horizontal blocks for 768 OCs at BF16
-    const int grid_size_y = max(1, block_size * dp.multiProcessorCount / (block_size * grid_size_x)); // full GPU!
-    return grid_size_y * OC * sizeof(float);
-}
-
-
 template<class floatX>
 void matmul_backward_imp(floatX* dinp, floatX* dweight, floatX* dbias,
                          const floatX* dout, const floatX* inp, const floatX* weight,
@@ -402,42 +265,17 @@ void matmul_backward_imp(floatX* dinp, floatX* dweight, floatX* dbias,
                          bool accumulate_gradient,
                          cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                          int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
-    using f128 = GenericVector<float, 16/sizeof(float)>;
-
     // backward to bias, if given, does a +=
     if (dbias != NULL) {
-        // Each warp is responsible for 8 * "x128::size" = 64 OCs at BF16 (OC must be a multiple of 64!)
-        // Block size is 1024 | 768 threads (32|24 warps) and we reduce those values into 1 at the end
-
-        const int block_size = dp.maxThreadsPerMultiProcessor == 1536 ? 768 : 1024;
-
-        dim3 block_dim = {4, 8, (unsigned)block_size/32};
-        const int OC_per_warp = block_dim.y * x128::size; // 64 at BF16
-        const int grid_size_x = div_ceil(OC, OC_per_warp); // e.g. 12 horizontal blocks for 768 OCs at BF16
-        const int grid_size_y = max(1, block_size * dp.multiProcessorCount / (block_size * grid_size_x)); // full GPU!
-
-        // If we have enough OC that we don't need cross-block reductions, we can skip the bias_buffer accumulation
-        // and write results directly to the output.
-        if(grid_size_y == 1) {
-            matmul_backward_bias_kernel9<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias, dout, nullptr, B, T, OC, std::bool_constant<false>());
-            CUDA_CHECK(cudaGetLastError());
-        } else {
-            // kernel 9 overwrites temp buffer, so no need to memset
-            matmul_backward_bias_kernel9<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias_buffer, dout, nullptr, B, T, OC, std::bool_constant<true>());
-            CUDA_CHECK(cudaGetLastError());
-            reduce_add_sum_kernel<<<div_ceil((size_t)OC, 256 * f128::size), 256, 0, stream>>>(dbias, dbias_buffer, OC, grid_size_y);
-            CUDA_CHECK(cudaGetLastError());
-        }
-        dbias = NULL; // prevent dbias calculation from also being fused in matmul_cublaslt below (if we enabled fusion)
+        backward_bias(dbias, dout, nullptr, dbias_buffer, B, T, OC, dp, stream);
     }
 
     // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, device_one, false, false, false, true);
+    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, device_one, false, false, false);
 
     // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout, (float*)nullptr /*dbias*/, workspace, workspace_size, C, OC, B*T, stream, handle, device_one, false, true,
-                    accumulate_gradient, true);
+    matmul_cublaslt(dweight, inp, dout, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, device_one, false, true,
+                    accumulate_gradient);
 }
 
 template<class floatX, class Float8>
@@ -447,43 +285,17 @@ void matmul_backward_fp8_imp(floatX* dinp, floatX* dweight, floatX* dbias,
                              bool accumulate_gradient,
                              cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
                              int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
-    using f128 = GenericVector<float, 16/sizeof(float)>;
-
-    // TODO
     // backward to bias, if given, does a +=
     if (dbias != NULL) {
-        // Each warp is responsible for 8 * "x128::size" = 64 OCs at BF16 (OC must be a multiple of 64!)
-        // Block size is 1024 | 768 threads (32|24 warps) and we reduce those values into 1 at the end
-
-        const int block_size = dp.maxThreadsPerMultiProcessor == 1536 ? 768 : 1024;
-
-        dim3 block_dim = {4, 8, (unsigned)block_size/32};
-        const int OC_per_warp = block_dim.y * x128::size; // 64 at BF16
-        const int grid_size_x = div_ceil(OC, OC_per_warp); // e.g. 12 horizontal blocks for 768 OCs at BF16
-        const int grid_size_y = max(1, block_size * dp.multiProcessorCount / (block_size * grid_size_x)); // full GPU!
-
-        // If we have enough OC that we don't need cross-block reductions, we can skip the bias_buffer accumulation
-        // and write results directly to the output.
-        if(grid_size_y == 1) {
-            matmul_backward_bias_kernel9<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias, dout, dout_abs_max, B, T, OC, std::bool_constant<false>());
-            CUDA_CHECK(cudaGetLastError());
-        } else {
-            // kernel 9 overwrites temp buffer, so no need to memset
-            matmul_backward_bias_kernel9<<<dim3(grid_size_x, grid_size_y), block_dim, 0, stream>>>(dbias_buffer, dout, dout_abs_max, B, T, OC, std::bool_constant<true>());
-            CUDA_CHECK(cudaGetLastError());
-            reduce_add_sum_kernel<<<div_ceil((size_t)OC, 256 * f128::size), 256, 0, stream>>>(dbias, dbias_buffer, OC, grid_size_y);
-            CUDA_CHECK(cudaGetLastError());
-        }
-        dbias = NULL; // prevent dbias calculation from also being fused in matmul_cublaslt below (if we enabled fusion)
+        backward_bias(dbias, dout, dout_abs_max, dbias_buffer, B, T, OC, dp, stream);
     }
 
     // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, dinp_scale, true, false, false, true);
+    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, dinp_scale, true, false, false);
 
     // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout_t, (float*)nullptr /*dbias*/, workspace, workspace_size, C, OC, B*T, stream, handle, dweight_scale, true, false,
-                    accumulate_gradient, true);
+    matmul_cublaslt(dweight, inp, dout_t, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, dweight_scale, true, false,
+                    accumulate_gradient);
 }
 
 void matmul_backward(float* dinp, float* dweight, float* dbias,

--- a/src/kernels/matmul.cpp
+++ b/src/kernels/matmul.cpp
@@ -19,6 +19,10 @@ cublasComputeType_t cublas_compute = CUBLAS_COMPUTE_32F;
 thread_local float* device_zero;
 thread_local float* device_one;
 
+float* get_device_one() {
+    return device_one;
+}
+
 // ----------------------------------------------------------------------------
 // Error checking
 
@@ -132,12 +136,6 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
     // set scale type to FP32 (needs to be FP16 if and only if using CUBLAS_COMPUTE_16F, so it's FP32 even for FP8!)
     cublasDataType_t scale_type = CUDA_R_32F;
     CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_SCALE_TYPE, &scale_type, sizeof(scale_type)));
-    if(scale != nullptr) {
-        std::int32_t device_pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
-        CUBLAS_CHECK(
-            cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &device_pointer_mode,
-                                           sizeof(device_pointer_mode)));
-    }
 
     // find a suitable algorithm (cached internally so shouldn't take much CPU time in practice)
     cublasLtMatmulAlgoGetHeuristic(handle, operationDesc, ALayout, BLayout, CLayout, DLayout,
@@ -155,6 +153,10 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
     if(scale != nullptr) {
         alpha = scale;
         beta = accumulate ? device_one : device_zero;
+        std::int32_t device_pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
+        CUBLAS_CHECK(
+            cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &device_pointer_mode,
+                                           sizeof(device_pointer_mode)));
     } else {
         // For some reason, using device_one/device_zero for bf16 x bf16 -> bf16 matmuls doesn't
         // work reliably
@@ -224,105 +226,3 @@ void matmul(float* c, const std::int8_t* a, const std::int8_t* b, const nv_bfloa
     }
 }
 */
-
-template<class floatX>
-void matmul_backward_imp(floatX* dinp, floatX* dweight, floatX* dbias,
-                         const floatX* dout, const floatX* inp, const floatX* weight,
-                         float* dbias_buffer, const float* dinp_scale, const float* dweight_scale,
-                         bool accumulate_gradient,
-                         cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                         int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    // backward to bias, if given, does a +=
-    if (dbias != NULL) {
-        backward_bias(dbias, dout, nullptr, dbias_buffer, B, T, OC, dp, stream);
-    }
-
-    // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, device_one, EMMTranspose::NN, false);
-
-    // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, device_one, EMMTranspose::NT,
-                    accumulate_gradient);
-}
-
-template<class floatX, class Float8>
-void matmul_backward_fp8_imp(floatX* dinp, floatX* dweight, floatX* dbias,
-                             const Float8* dout, const Float8* dout_t, const Float8* inp, const Float8* weight,
-                             float* dbias_buffer, const float* dinp_scale, const float* dweight_scale, const float* dout_abs_max,
-                             bool accumulate_gradient,
-                             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                             int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    // backward to bias, if given, does a +=
-    if (dbias != NULL) {
-        backward_bias(dbias, dout, dout_abs_max, dbias_buffer, B, T, OC, dp, stream);
-    }
-
-    // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, dinp_scale, EMMTranspose::TN, false);
-
-    // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout_t, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, dweight_scale, EMMTranspose::TN,
-                    accumulate_gradient);
-}
-
-void matmul_backward(float* dinp, float* dweight, float* dbias,
-                     const float* dout, const float* inp, const float* weight,
-                     float* dbias_buffer, const float* dinp_scale, const float* dweight_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    matmul_backward_imp(dinp, dweight, dbias, dout, inp, weight, dbias_buffer, dinp_scale, dweight_scale,
-                        accumulate_gradient, handle, workspace, workspace_size, B, T, C, OC, dp, stream);
-}
-
-void matmul_backward(nv_bfloat16* dinp, nv_bfloat16* dweight, nv_bfloat16* dbias,
-                     const nv_bfloat16* dout, const nv_bfloat16* inp, const nv_bfloat16* weight,
-                     float* dbias_buffer, const float* dinp_scale, const float* dweight_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    matmul_backward_imp(dinp, dweight, dbias, dout, inp, weight, dbias_buffer, dinp_scale, dweight_scale,
-                        accumulate_gradient, handle, workspace, workspace_size, B, T, C, OC, dp, stream);
-}
-
-void matmul_backward(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,
-                     const Tensor& dout, const Tensor& inp, const Tensor& weight,
-                     std::optional<Tensor> dbias_buffer, const float* dinp_scale, const float* dweight_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, Tensor& workspace,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    std::byte* ws = workspace.get<std::byte>();
-    std::size_t ws_size = workspace.bytes();
-    if(dinp.DType == ETensorDType::FP32 && inp.DType == ETensorDType::FP32) {
-        float* d_bias_ptr = dbias.has_value() ? dbias.value().get<float>() : nullptr;
-        float* bias_buffer_ptr = dbias_buffer.has_value() ? dbias_buffer.value().get<float>() : nullptr;
-        matmul_backward(dinp.get<float>(), dweight.get<float>(), d_bias_ptr, dout.get<float>(), inp.get<float>(), weight.get<float>(),
-                        bias_buffer_ptr, dinp_scale, dweight_scale, accumulate_gradient, handle, ws, ws_size, B, T, C, OC, dp, stream);
-    } else if(dinp.DType == ETensorDType::BF16 && inp.DType == ETensorDType::BF16) {
-        nv_bfloat16* d_bias_ptr = dbias.has_value() ? dbias.value().get<nv_bfloat16>() : nullptr;
-        float* bias_buffer_ptr = dbias_buffer.has_value() ? dbias_buffer.value().get<float>() : nullptr;
-        matmul_backward(dinp.get<nv_bfloat16>(), dweight.get<nv_bfloat16>(), d_bias_ptr, dout.get<nv_bfloat16>(), inp.get<nv_bfloat16>(), weight.get<nv_bfloat16>(),
-                        bias_buffer_ptr, dinp_scale, dweight_scale, accumulate_gradient, handle, ws, ws_size, B, T, C, OC, dp, stream);
-    } else {
-        throw std::logic_error("matmul_forward: invalid DType combination");
-    }
-}
-
-void matmul_backward_fp8(Tensor dinp, Tensor dweight, std::optional<Tensor> dbias,
-                     const Tensor& dout, const Tensor& dout_t, const Tensor& inp, const Tensor& weight,
-                     std::optional<Tensor> dbias_buffer, const float* dinp_scale, const float* dweight_scale, const float* dout_scale,
-                     bool accumulate_gradient,
-                     cublasLtHandle_t handle, Tensor& workspace,
-                     int B, int T, int C, int OC, const cudaDeviceProp& dp, cudaStream_t stream) {
-    std::byte* ws = workspace.get<std::byte>();
-    std::size_t ws_size = workspace.bytes();
-    if(dinp.DType == ETensorDType::BF16 && inp.DType == ETensorDType::FP8_E4M3) {
-        nv_bfloat16* d_bias_ptr = dbias.has_value() ? dbias.value().get<nv_bfloat16>() : nullptr;
-        float* bias_buffer_ptr = dbias_buffer.has_value() ? dbias_buffer.value().get<float>() : nullptr;
-        matmul_backward_fp8_imp(dinp.get<nv_bfloat16>(), dweight.get<nv_bfloat16>(), d_bias_ptr,
-            dout.get<__nv_fp8_e4m3>(), dout_t.get<__nv_fp8_e4m3>(), inp.get<__nv_fp8_e4m3>(), weight.get<__nv_fp8_e4m3>(),
-                                bias_buffer_ptr, dinp_scale, dweight_scale, dout_scale, accumulate_gradient, handle, ws, ws_size, B, T, C, OC, dp, stream);
-    }  else {
-        throw std::logic_error("matmul_backward_fp8: invalid DType combination");
-    }
-}

--- a/src/kernels/matmul.cpp
+++ b/src/kernels/matmul.cpp
@@ -180,45 +180,45 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
 
 void matmul(float* c, const float* a, const float* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 void matmul(float* c, const nv_bfloat16* a, const nv_bfloat16* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const float* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 void matmul(nv_bfloat16* c, const nv_bfloat16* a, const nv_bfloat16* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 void matmul(nv_bfloat16* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
 }
 
 /*
 void matmul(float* c, const std::int8_t* a, const std::int8_t* b, const nv_bfloat16* bias, const float* scale,
             cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
-    matmul_cublaslt(c, b, a, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+            int M, int N, int K, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, b, a, bias, workspace, workspace_size, M, N, K, stream, handle, scale, mode, accumulate);
     if(bias) {
         add_bias(c, bias, B, T, OC, stream);
     }

--- a/src/kernels/matmul.cpp
+++ b/src/kernels/matmul.cpp
@@ -62,8 +62,7 @@ template<class floatO, class floatX, class floatB>
 void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* bias,
                      std::byte* workspace, std::size_t workspace_size,
                      int m, int n, int k, cudaStream_t stream, cublasLtHandle_t handle,
-                     const float* scale=nullptr, bool transA=true, bool transB=false,
-                     bool accumulate=false)
+                     const float* scale, EMMTranspose mode, bool accumulate)
 {
     bool has_bias = (bias != nullptr);
 
@@ -83,6 +82,9 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
     int returnedResults = 0;
     cublasLtMatmulPreference_t preference;
     cublasLtMatmulHeuristicResult_t heuristic;
+
+    bool transA = mode == EMMTranspose::TN || mode == EMMTranspose::TT;
+    bool transB = mode == EMMTranspose::NT || mode == EMMTranspose::TT;
 
     cublasOperation_t opNoTranspose = CUBLAS_OP_N;
     cublasOperation_t opTranspose = CUBLAS_OP_T;
@@ -176,87 +178,52 @@ void matmul_cublaslt(floatO* d, const floatX* a, const floatX* b, const floatB* 
     CUDA_CHECK(cudaGetLastError());
 }
 
-// small wrapper around matmul_cublaslt for the forward pass (keeping historical order of arguments)
-void matmul_forward(float* out, const float* inp, const float* weight, const float* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, true, false, false);
+void matmul(float* c, const float* a, const float* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
 }
 
-void matmul_forward(float* out, const nv_bfloat16* inp, const nv_bfloat16* weight, const float* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
+void matmul(float* c, const nv_bfloat16* a, const nv_bfloat16* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
 }
 
-void matmul_forward(float* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const float* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
+void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const float* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
 }
 
-void matmul_forward(float* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const nv_bfloat16* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
+void matmul(float* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
 }
 
-void matmul_forward(float* out, const std::int8_t* inp, const std::int8_t* weight, const float* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
+void matmul(nv_bfloat16* c, const nv_bfloat16* a, const nv_bfloat16* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+}
+
+void matmul(nv_bfloat16* c, const __nv_fp8_e4m3* a, const __nv_fp8_e4m3* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, a, b, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
+}
+
+/*
+void matmul(float* c, const std::int8_t* a, const std::int8_t* b, const nv_bfloat16* bias, const float* scale,
+            cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
+            int B, int T, int C, int OC, EMMTranspose mode, bool accumulate, cudaStream_t stream) {
+    matmul_cublaslt(c, b, a, bias, workspace, workspace_size, OC, B*T, C, stream, handle, scale, mode, accumulate);
     if(bias) {
-        add_bias(out, bias, B, T, OC, stream);
+        add_bias(c, bias, B, T, OC, stream);
     }
 }
-
-void matmul_forward(nv_bfloat16* out, const nv_bfloat16* inp, const nv_bfloat16* weight, const nv_bfloat16* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
-}
-
-void matmul_forward(nv_bfloat16* out, const __nv_fp8_e4m3* inp, const __nv_fp8_e4m3* weight, const nv_bfloat16* bias, const float* scale,
-                    cublasLtHandle_t handle, std::byte* workspace, std::size_t workspace_size,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    matmul_cublaslt(out, weight, inp, bias, workspace, workspace_size, OC, B*T, C, stream, handle,  scale, true, false, false);
-}
-
-void matmul_forward(Tensor& out, const Tensor& inp, const Tensor& weight, std::optional<Tensor> bias, const float* scale,
-                    cublasLtHandle_t handle, Tensor& workspace,
-                    int B, int T, int C, int OC, cudaStream_t stream) {
-    std::byte* ws = workspace.get<std::byte>();
-    std::size_t ws_size = workspace.bytes();
-    if(out.DType == ETensorDType::FP32 && inp.DType == ETensorDType::FP32) {
-        float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
-        matmul_forward(out.get<float>(), inp.get<float>(), weight.get<float>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-    } else if(out.DType == ETensorDType::FP32 && inp.DType == ETensorDType::BF16) {
-        float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
-        matmul_forward(out.get<float>(), inp.get<nv_bfloat16>(), weight.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-    } else if(out.DType == ETensorDType::FP32 && inp.DType == ETensorDType::INT8) {
-        float* bias_ptr = bias.has_value() ? bias.value().get<float>() : nullptr;
-        matmul_forward(out.get<float>(), inp.get<std::int8_t>(), weight.get<std::int8_t>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-    } else if(out.DType == ETensorDType::FP32 && inp.DType == ETensorDType::FP8_E4M3) {
-        if(bias.has_value()) {
-            // even with 32-bit C, bias needs to be bf16 ?!
-            if(bias.value().DType == ETensorDType::BF16) {
-                matmul_forward(out.get<float>(), inp.get<__nv_fp8_e4m3>(), weight.get<__nv_fp8_e4m3>(), bias->get<nv_bfloat16>(), scale,handle, ws, ws_size, B, T, C, OC, stream);
-            } else {
-                matmul_forward(out.get<float>(), inp.get<__nv_fp8_e4m3>(), weight.get<__nv_fp8_e4m3>(), bias->get<float>(), scale,handle, ws, ws_size, B, T, C, OC, stream);
-            }
-        } else {
-            matmul_forward(out.get<float>(), inp.get<__nv_fp8_e4m3>(), weight.get<__nv_fp8_e4m3>(), (nv_bfloat16*)nullptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-        }
-    } else if(out.DType == ETensorDType::BF16 && inp.DType == ETensorDType::FP8_E4M3) {
-        nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
-        matmul_forward(out.get<nv_bfloat16>(), inp.get<__nv_fp8_e4m3>(), weight.get<__nv_fp8_e4m3>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-    } else if(out.DType == ETensorDType::BF16) {
-        nv_bfloat16* bias_ptr = bias.has_value() ? bias.value().get<nv_bfloat16>() : nullptr;
-        matmul_forward(out.get<nv_bfloat16>(), inp.get<nv_bfloat16>(), weight.get<nv_bfloat16>(), bias_ptr, scale,handle, ws, ws_size, B, T, C, OC, stream);
-    } else {
-        throw std::logic_error("matmul_forward: invalid DType combination");
-    }
-}
+*/
 
 template<class floatX>
 void matmul_backward_imp(floatX* dinp, floatX* dweight, floatX* dbias,
@@ -271,10 +238,10 @@ void matmul_backward_imp(floatX* dinp, floatX* dweight, floatX* dbias,
     }
 
     // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, device_one, false, false, false);
+    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, device_one, EMMTranspose::NN, false);
 
     // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, device_one, false, true,
+    matmul_cublaslt(dweight, inp, dout, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, device_one, EMMTranspose::NT,
                     accumulate_gradient);
 }
 
@@ -291,10 +258,10 @@ void matmul_backward_fp8_imp(floatX* dinp, floatX* dweight, floatX* dbias,
     }
 
     // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, dinp_scale, true, false, false);
+    matmul_cublaslt(dinp, weight, dout, (float*)nullptr, workspace, workspace_size, C, B*T, OC, stream, handle, dinp_scale, EMMTranspose::TN, false);
 
     // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    matmul_cublaslt(dweight, inp, dout_t, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, dweight_scale, true, false,
+    matmul_cublaslt(dweight, inp, dout_t, (float*)nullptr, workspace, workspace_size, C, OC, B*T, stream, handle, dweight_scale, EMMTranspose::TN,
                     accumulate_gradient);
 }
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -26,7 +26,7 @@ void forward_qmm(Tensor& out, QuantizableTensor& inp, Tensor& weight, std::optio
                       const cudaDeviceProp& dp, bool reuse_inp_quant, bool inp_has_abs_max,
                       cudaStream_t stream) {
     if (weight.DType == inp.Value.DType) {
-        matmul(out, weight, inp.Value, bias, nullptr, handle, workspace, B, T, C, OC, EMMTranspose::TN, false, stream);
+        matmul(out, weight, inp.Value, bias, nullptr, handle, workspace, OC, B*T, C, EMMTranspose::TN, false, stream);
     } else {
         float* act_scale = inp.Quant->Scales;
         float* wgt_scale = weight.Scales;
@@ -41,7 +41,7 @@ void forward_qmm(Tensor& out, QuantizableTensor& inp, Tensor& weight, std::optio
 
         float scale = weight.DType == ETensorDType::FP8_E4M3 ? 448.f : std::numeric_limits<std::int8_t>::max();
         matmul_out_scale(out_scale, act_scale, wgt_scale, 1.f / scale / scale, stream);
-        matmul(out, weight, inp.Quant.value(), bias, out_scale, handle, workspace, B, T, C, OC, EMMTranspose::TN, false, stream);
+        matmul(out, weight, inp.Quant.value(), bias, out_scale, handle, workspace, OC, B*T, C, EMMTranspose::TN, false, stream);
     }
 }
 
@@ -150,7 +150,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
 
     Parameters->gather_head(comm);
     matmul(rs->Output, Parameters->get_head(main_stream), rs->LNF,
-           std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, B, T, C, V, EMMTranspose::TN, false, main_stream);
+           std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, V, B*T, C, EMMTranspose::TN, false, main_stream);
     Parameters->release_head(main_stream);
 
     // do not return before inputs can be accessed again.

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -346,14 +346,17 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
 
     // BackwardDone ensures that zero-2 gradient accumulation of the previous step has finished, so we can safely write to d_lmhead again.
     CUDA_CHECK(cudaEventSynchronize(rs->BackwardDone));
+
+    // handle the LM-head. We run the d_lmhead matmul first, so that the gradient reduction can overlap with the DLNF matmul.
     auto& d_lmhead = Grads->get_lmhead_full(main_stream, comm, accumulate);
+    matmul(d_lmhead, rs->LNF, rs->Output, std::nullopt, get_device_one(), rs->CublasLtHandle, rs->Workspace, C, V, B*T, EMMTranspose::NT, accumulate, main_stream);
+    Grads->notify_lmhead(main_stream, comm);
+
     Parameters->gather_head(comm);
     // for some reason, we cannot set scale == nullptr here ?!
     // so instead supply the value one (get_device_one())
     matmul(rs->DLNF, Parameters->get_head(main_stream), rs->Output, std::nullopt, get_device_one(), rs->CublasLtHandle, rs->Workspace, C, B*T, V, EMMTranspose::NN, false, main_stream);
-    matmul(d_lmhead, rs->LNF, rs->Output, std::nullopt, get_device_one(), rs->CublasLtHandle, rs->Workspace, C, V, B*T, EMMTranspose::NT, accumulate, main_stream);
     Parameters->release_head(main_stream);
-    Grads->notify_lmhead(main_stream, comm);
 
     auto& d_lnf_w = Grads->get_lnf_w_full(main_stream, comm, accumulate);
     Parameters->gather_lnf(comm);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -26,7 +26,7 @@ void forward_qmm(Tensor& out, QuantizableTensor& inp, Tensor& weight, std::optio
                       const cudaDeviceProp& dp, bool reuse_inp_quant, bool inp_has_abs_max,
                       cudaStream_t stream) {
     if (weight.DType == inp.Value.DType) {
-        matmul_forward(out, inp.Value, weight, bias, nullptr, handle, workspace, B, T, C, OC, stream);
+        matmul(out, weight, inp.Value, bias, nullptr, handle, workspace, B, T, C, OC, EMMTranspose::TN, false, stream);
     } else {
         float* act_scale = inp.Quant->Scales;
         float* wgt_scale = weight.Scales;
@@ -41,7 +41,7 @@ void forward_qmm(Tensor& out, QuantizableTensor& inp, Tensor& weight, std::optio
 
         float scale = weight.DType == ETensorDType::FP8_E4M3 ? 448.f : std::numeric_limits<std::int8_t>::max();
         matmul_out_scale(out_scale, act_scale, wgt_scale, 1.f / scale / scale, stream);
-        matmul_forward(out, inp.Quant.value(), weight, bias, out_scale, handle, workspace, B, T, C, OC, stream);
+        matmul(out, weight, inp.Quant.value(), bias, out_scale, handle, workspace, B, T, C, OC, EMMTranspose::TN, false, stream);
     }
 }
 
@@ -149,9 +149,8 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
     }
 
     Parameters->gather_head(comm);
-    // TODO V vs Vp
-    matmul_forward(rs->Output, rs->LNF, Parameters->get_head(main_stream),
-                   std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, B, T, C, V, main_stream);
+    matmul(rs->Output, Parameters->get_head(main_stream), rs->LNF,
+           std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, B, T, C, V, EMMTranspose::TN, false, main_stream);
     Parameters->release_head(main_stream);
 
     // do not return before inputs can be accessed again.

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -12,6 +12,8 @@
 #include "llama_weights.h"
 #include "utilities/comm.h"
 
+extern float* get_device_one();
+
 LLamaModel::LLamaModel(LLamaConfig config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc) :
         Config(config), Options(options), Allocator(alloc ? alloc : std::make_shared<TensorAllocator>())
 {
@@ -244,8 +246,12 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
                   int B, int T, int C, int OC,
                   bool reuse_inp, bool dout_has_absmax, cudaStream_t stream) {
     if (weight.DType == inp.Value.DType) {
-        matmul_backward(dinp, dweight, dbias, dout.Value, inp.Value, weight, bias_buffer, nullptr, nullptr, accumulate_gradient,
-                        rs.CublasLtHandle, rs.Workspace, B, T, C, OC, rs.DeviceProp, stream);
+        matmul(dinp, weight, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::NN, false, stream);
+        matmul(dweight, inp.Value, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::NT, accumulate_gradient, stream);
+
+        if (dbias.has_value()) {
+            backward_bias(dbias.value(), dout.Value, nullptr, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
+        }
     } else {
         float* act_scale = inp.Quant->Scales;
         float* wgt_scale = weight.Scales;
@@ -273,8 +279,11 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
         matmul_out_scale(dinp_scale, dout_scale, wgt_scale, 1.f / scale / scale, stream);
         matmul_out_scale(dwgt_scale, dout_scale, act_scale, 1.f / scale / scale, stream);
 
-        matmul_backward_fp8(dinp, dweight, dbias, dout.Quant.value(), rs.GradientTranspose, rs.ActivationTranspose, rs.WeightTranspose,
-                            bias_buffer, dinp_scale, dwgt_scale, dout_scale, accumulate_gradient, rs.CublasLtHandle, rs.Workspace, B, T, C, OC, rs.DeviceProp, stream);
+        matmul(dinp, rs.WeightTranspose, dout.Quant.value(), std::nullopt, dinp_scale, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::TN, false, stream);
+        matmul(dweight, rs.ActivationTranspose, rs.GradientTranspose, std::nullopt, dwgt_scale, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::TN, accumulate_gradient, stream);
+        if (dbias.has_value()) {
+            backward_bias(dbias.value(), dout.Quant.value(), dout_scale, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
+        }
     }
 }
 
@@ -335,12 +344,14 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     // ZeRO-3 note: We just finished the forward pass, so LMHead and LNF_w are still available locally, no further gathering needed.
     //              Same for layer L-1, so the first thing we need to prefetch is L-2 down in the loop below.
 
-    // BackwarDone ensures that zero-2 gradient accumulation of the previous step has finished, so we can safely write to d_lmhead again.
+    // BackwardDone ensures that zero-2 gradient accumulation of the previous step has finished, so we can safely write to d_lmhead again.
     CUDA_CHECK(cudaEventSynchronize(rs->BackwardDone));
     auto& d_lmhead = Grads->get_lmhead_full(main_stream, comm, accumulate);
     Parameters->gather_head(comm);
-    matmul_backward(rs->DLNF, d_lmhead, std::nullopt, rs->Output, rs->LNF, Parameters->get_head(main_stream), std::nullopt,
-                    nullptr, nullptr, accumulate, rs->CublasLtHandle, rs->Workspace, B, T, C, Vp, rs->DeviceProp, main_stream);
+    // for some reason, we cannot set scale == nullptr here ?!
+    // so instead supply the value one (get_device_one())
+    matmul(rs->DLNF, Parameters->get_head(main_stream), rs->Output, std::nullopt, get_device_one(), rs->CublasLtHandle, rs->Workspace, C, B*T, V, EMMTranspose::NN, false, main_stream);
+    matmul(d_lmhead, rs->LNF, rs->Output, std::nullopt, get_device_one(), rs->CublasLtHandle, rs->Workspace, C, V, B*T, EMMTranspose::NT, accumulate, main_stream);
     Parameters->release_head(main_stream);
     Grads->notify_lmhead(main_stream, comm);
 


### PR DESCRIPTION
Drastically clean up the matmul code. Instead of forward/backward, have one matmul in kernels, and let model make sure to call the right ones.

This also enables us to split the backward for the classification layer in such a way that we can overlap one of the two matmuls with the gradient reduction, for slightly better comp/comm overlap.