### PR TITLE
Explicit pre-fetching for offloaded master-parameters

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -128,8 +128,6 @@ jobs:
             args: "--recompute-swiglu --recompute-norm"
           - name: "Offload Opt"
             args: "--offload-opt-m --offload-opt-v --offload-master"
-          - name: "Persistent Quants"
-            args: "--persistent-quants"
         dtype:
           - name: "BF16"
             args: "--matmul-dtype=bf16"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(llmq-common SHARED
         src/models/llama_weights.cpp
         src/models/llama_gradients.cpp
         src/models/llama_config.cpp
+        src/models/llama_optimizer.cpp
 
         src/kernels/kernels.cpp
         src/kernels/encoder.cu

--- a/README.md
+++ b/README.md
@@ -353,37 +353,41 @@ The run marked with * uses additional arguments `--shard-weights --memcpy-all-ga
 ^1: `--recompute-swiglu --recompute-norm` to fit batch size 4. Smaller batch sizes drastically reduce efficiency.
 
 ### RTX 4090
+
+All settings use `--lmhead-chunks=${BATCH_SIZE}`
+
 | Model         | nGPU | DType | Batch | TPS  | SOL | TTB   |
 |---------------|------|-------|-------|------|-----|-------|
-| Qwen2.5-0.5B  | 1    | fp8   | 8     | 49k  | 60% | 5.40h |
-| Qwen2.5-0.5B  | 1    | bf16  | 8     | 40k  | 75% | 6:56h |
-| Qwen2.5-1.5B  | 1    | fp8   | 4     | 19k  | 67% | 14h   |
-| Qwen2.5-1.5B  | 1    | bf16  | 4     | 14k  | 80% | 20h   |
-| Qwen2.5-3B¹   | 1    | fp8   | 4     | 7.9k | 51% | 35h   |
-| Qwen2.5-3B²   | 1    | bf16  | 4     | 6.2k | 71% | 45h   |
-| Qwen2.5-7B³   | 1    | fp8   | 4     | 3.0k | 44% | 92h   |
-| Qwen2.5-7B⁴   | 1    | bf16  | 4     | 1.9k | 27% | 146h  |
-| Qwen2.5-0.5B  | 4    | fp8   | 8     | 185k | 57% | 1:30h |
-| Qwen2.5-0.5B  | 4    | bf16  | 8     | 151k | 71% | 1:50h |
-| Qwen2.5-1.5B⁵ | 4    | fp8   | 8     | 67k  | 57% | 4:08h |
-| Qwen2.5-1.5B⁵ | 4    | bf16  | 8     | 47k  | 68% | 5:54h |
-| Qwen2.5-3B²   | 4    | fp8   | 4     | 34k  | 55% | 8:10h |
-| Qwen2.5-3B²   | 4    | bf16  | 4     | 24k  | 69% | 12h   |
-| Qwen2.5-7B⁶   | 4    | fp8   | 8     | 13k  | 47% | 21h   |
-| Qwen2.5-7B⁷   | 4    | bf16  | 8     | 7.0k | 46% | 40h   |
-| Qwen2.5-14B⁸  | 4    | fp8   | 8     | 6.0k | 42% | 47h   |
-| Qwen2.5-14B⁹  | 4    | bf16  | 8     | 4.5k | 58% | 62h   |
+| Qwen2.5-0.5B  | 1    | fp8   | 16    | 48k  | 59% | 5.47h |
+| Qwen2.5-0.5B  | 1    | bf16  | 16    | 41k  | 76% | 6:48h |
+| Qwen2.5-1.5B  | 1    | fp8   | 4     | 20k  | 70% | 14h   |
+| Qwen2.5-1.5B  | 1    | bf16  | 4     | 14k  | 83% | 19h   |
+| Qwen2.5-3B¹   | 1    | fp8   | 4     | 10k  | 66% | 28h   |
+| Qwen2.5-3B²   | 1    | bf16  | 4     | 7.0k | 80% | 40h   |
+| Qwen2.5-7B³   | 1    | fp8   | 4     | 3.9k | 56% | 71h   |
+| Qwen2.5-7B⁴   | 1    | bf16  | 4     | 2.4k | 64% | 116h  |
+| Qwen2.5-0.5B  | 4    | fp8   | 16    | 173k | 53% | 1:35h |
+| Qwen2.5-0.5B  | 4    | bf16  | 16    | 148k | 69% | 1:52h |
+| Qwen2.5-1.5B  | 4    | fp8   | 8     | 70k  | 60% | 3:56h |
+| Qwen2.5-1.5B⁵ | 4    | bf16  | 8     | 50k  | 73% | 5:30h |
+| Qwen2.5-3B¹⁰  | 4    | fp8   | 4     | 36k  | 58% | 7:40h |
+| Qwen2.5-3B¹⁰  | 4    | bf16  | 4     | 25k  | 71% | 11h   |
+| Qwen2.5-7B⁶   | 4    | fp8   | 16    | 16k  | 57% | 17h   |
+| Qwen2.5-7B⁷   | 4    | bf16  | 16    | 9.3k | 61% | 30h   |
+| Qwen2.5-14B⁸  | 4    | fp8   | 8     | 7.3k | 51% | 38h   |
+| Qwen2.5-14B⁹  | 4    | bf16  | 8     | 3.5k | 46% | 78h   |
 
 
-^1: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm --offload-master`  
+^1: `--offload-opt-m --offload-opt-v --recompute-swiglu --offload-master`  
 ^2: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm`  
-^3: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --persistent-quants --offload-quants`  
+^3: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --persistent-quants --offload-quants --memcpy-all-gather`  
 ^4: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather`  
 ^5: `--recompute-norm --recompute-swiglu` 
 ^6: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
 ^7: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce` 
 ^8: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
 ^9: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce`  
+^10: `--offload-opt-m --recompute-swiglu --recompute-norm`
 
 ### L40S
 

--- a/src/binding/python/tests/recompute.py
+++ b/src/binding/python/tests/recompute.py
@@ -29,6 +29,9 @@ def disable_recompute(config: RunConfig):
     baseline_config.recompute_att = False
     baseline_config.recompute_block = False
     baseline_config.use_cuda_graphs = False
+    baseline_config.offload_master = False
+    baseline_config.offload_opt_v = False
+    baseline_config.offload_opt_m = False
     return baseline_config
 
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -690,7 +690,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
     for(int i = 0; i < Config.NumLayers; i++) {
         NvtxRange layer_range("Layer", i);
-        Parameters->gather_master_block(i, comm.stream());
+        Parameters->fetch_master_block(i, comm.stream());
         auto& bw = Parameters->get_master_block(i, main_stream);
         auto& bg = Grads->get_block_shard(i, main_stream);
         auto& bm = opt_m.Blocks[i];

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -709,7 +709,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         run_update(bw.MLP_Up_w, bg.MLP_Up_w, bm.MLP_Up_w, bv.MLP_Up_w, weight_decay);
         run_update(bw.MLP_Down_w, bg.MLP_Down_w, bm.MLP_Down_w, bv.MLP_Down_w, weight_decay);
 
-        Parameters->release_master_block(i, main_stream, rs->SideStream);
+        Parameters->release_master_block(i, main_stream, rs->SideStream, *rs);
 
         CUDA_CHECK(cudaEventRecord(rs->LayerUpdateDone[i], main_stream));
     }

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -690,7 +690,8 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
     for(int i = 0; i < Config.NumLayers; i++) {
         NvtxRange layer_range("Layer", i);
-        auto& bw = Parameters->get_master_block(i);
+        Parameters->gather_master_block(i, comm.stream());
+        auto& bw = Parameters->get_master_block(i, main_stream);
         auto& bg = Grads->get_block_shard(i, main_stream);
         auto& bm = opt_m.Blocks[i];
         auto& bv = opt_v.Blocks[i];
@@ -707,6 +708,8 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
         run_update(bw.MLP_Up_w, bg.MLP_Up_w, bm.MLP_Up_w, bv.MLP_Up_w, weight_decay);
         run_update(bw.MLP_Down_w, bg.MLP_Down_w, bm.MLP_Down_w, bv.MLP_Down_w, weight_decay);
+
+        Parameters->release_master_block(i, main_stream, rs->SideStream);
 
         CUDA_CHECK(cudaEventRecord(rs->LayerUpdateDone[i], main_stream));
     }

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -9,6 +9,7 @@
 
 #include "kernels/kernels.h"
 #include "llama_gradients.h"
+#include "llama_optimizer.h"
 #include "llama_run_state.h"
 #include "llama_weights.h"
 #include "utilities/comm.h"
@@ -662,12 +663,9 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
     auto& rs = RunState;
     cudaStream_t main_stream = rs->MainStream;
 
-    if(!OptM || !OptV) {
+    if(!OptimizerState) {
         throw std::logic_error("LLamaModel::update() but no optimizer available");
     }
-
-    auto& opt_m = *OptM;
-    auto& opt_v = *OptV;
 
     auto& rng = OptimizerRNG;
 
@@ -683,19 +681,22 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
                      learning_rate, beta_1, beta_2, t, epsilon, wd, grad_scale, val.Scales, rng(), main_stream);
     };
 
-    run_update(Parameters->get_master_embeddings(), Grads->get_embeddings_shard(main_stream), opt_m.NonBlocks.Embeddings, opt_v.NonBlocks.Embeddings, weight_decay);
+    run_update(Parameters->get_master_embeddings(), Grads->get_embeddings_shard(main_stream),
+               OptimizerState->non_block_m().Embeddings, OptimizerState->non_block_v().Embeddings, weight_decay);
     comm.reduce_max(Parameters->get_master_embeddings().Scales);
-    run_update(Parameters->get_master_lnf_w(), Grads->get_lnf_w_shard(main_stream), opt_m.NonBlocks.LNF_w, opt_v.NonBlocks.LNF_w, 0.f);
+    run_update(Parameters->get_master_lnf_w(), Grads->get_lnf_w_shard(main_stream),
+               OptimizerState->non_block_m().LNF_w, OptimizerState->non_block_v().LNF_w, 0.f);
     comm.reduce_max(Parameters->get_master_lnf_w().Scales);
     CUDA_CHECK(cudaEventRecord(rs->OptEmbeddingsDone, main_stream));
 
     for(int i = 0; i < Config.NumLayers; i++) {
         NvtxRange layer_range("Layer", i);
         Parameters->fetch_master_block(i, comm.stream());
+        OptimizerState->fetch_block(i, comm.stream());
         auto& bw = Parameters->get_master_block(i, main_stream);
         auto& bg = Grads->get_block_shard(i, main_stream);
-        auto& bm = opt_m.Blocks[i];
-        auto& bv = opt_v.Blocks[i];
+        auto& bm = OptimizerState->get_block_m(i, main_stream);
+        auto& bv = OptimizerState->get_block_v(i, main_stream);
         run_update(bw.LN1_w, bg.LN1_w, bm.LN1_w, bv.LN1_w, 0.f);
         run_update(bw.LN2_w, bg.LN2_w, bm.LN2_w, bv.LN2_w, 0.f);
 
@@ -718,36 +719,18 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         //      matter (e.g., for small models), we can investigate more.
         comm.reduce_max(scales.first, scales.second - scales.first, main_stream);
         Parameters->release_master_block(i, main_stream, rs->SideStream, *rs);
+        OptimizerState->store_block(i, main_stream, rs->SideStream);
 
         CUDA_CHECK(cudaEventRecord(rs->LayerUpdateDone[i], main_stream));
     }
 
     if(!Config.TiedWordEmbeddings) {
-        run_update(Parameters->get_master_lmhead(), Grads->get_lmhead_shard(main_stream), opt_m.NonBlocks.LMHead, opt_v.NonBlocks.LMHead, weight_decay);
+        run_update(Parameters->get_master_lmhead(), Grads->get_lmhead_shard(main_stream),
+                   OptimizerState->non_block_m().LMHead, OptimizerState->non_block_v().LMHead, weight_decay);
         comm.reduce_max(Parameters->get_master_lmhead().Scales);
     }
     comm.wait_on_comms(main_stream);
     CUDA_CHECK(cudaEventRecord(rs->OptimizerDone, main_stream));
-}
-
-void zero_opt_buffer(sLLamaWeights& weights, cudaStream_t stream) {
-    // here's the first disadvantage of having individual buffers: We need to make a ton of memset calls
-    fill_zero(weights.NonBlocks.Embeddings, stream);
-    fill_zero(weights.NonBlocks.LNF_w, stream);
-    if(weights.NonBlocks.LMHead.Data != weights.NonBlocks.Embeddings.Data) {
-        fill_zero(weights.NonBlocks.LMHead, stream);
-    }
-    for(auto& layer: weights.Blocks) {
-        fill_zero(layer.LN1_w, stream);
-        fill_zero(layer.LN2_w, stream);
-        fill_zero(layer.Attn_QKV_w, stream);
-        if(auto& qkv_b = layer.Attn_QKV_b; qkv_b.has_value()) {
-            fill_zero(qkv_b.value(), stream);
-        }
-        fill_zero(layer.Attn_Out_w, stream);
-        fill_zero(layer.MLP_Up_w, stream);
-        fill_zero(layer.MLP_Down_w, stream);
-    }
 }
 
 void LLamaModel::allocate_run_state(const LLamaOptions& options, NCCLCommunicator& comm, int B, int T) {
@@ -763,26 +746,9 @@ void LLamaModel::allocate_run_state(const LLamaOptions& options, NCCLCommunicato
         Grads = LLamaGradsManager::create(42, 0, Config, options, comm.rank(), comm.world_size(), Allocator);
     }
 
-    {
-        auto ctx = Allocator->with_context("Adam M");
-        EAllocationType alloc_type = options.OffloadOptM ? options.offload_alloc() : EAllocationType::ON_DEVICE;
-        LLamaConfig c = Config;
-        c.DType = acts.Options.OptMomentumType;
-        OptM = std::make_unique<sLLamaWeights>(allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), *Allocator));
-        zero_opt_buffer(*OptM, acts.MainStream);
-    }
-
-    {
-        auto ctx = Allocator->with_context("Adam V");
-        EAllocationType alloc_type = options.OffloadOptV ? options.offload_alloc() : EAllocationType::ON_DEVICE;
-        LLamaConfig c = Config;
-        c.DType = acts.Options.OptVarianceType;
-        OptV = std::make_unique<sLLamaWeights>(allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), *Allocator));
-        zero_opt_buffer(*OptV, acts.MainStream);
-    }
-
     OptimizerRNG = std::minstd_rand{42};
     RunState = std::make_unique<LLamaRunState>(std::move(acts));
+    OptimizerState = std::make_unique<LLamaOptimizerStateManager>(Config, options, RunState->MainStream, comm, *Allocator);
     comm.barrier();     // make sure *all* GPUs have allocated the model before returning
 }
 
@@ -791,11 +757,11 @@ ITensorContainer& LLamaModel::weights() {
 }
 
 ITensorContainer& LLamaModel::opt_momentum() {
-    return *OptM;
+    return OptimizerState->full_m();
 }
 
 ITensorContainer& LLamaModel::opt_variance() {
-    return *OptV;
+    return OptimizerState->full_v();
 }
 
 std::vector<std::byte> LLamaModel::rng_state() const {

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -681,11 +681,12 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
     auto run_update = [&](Tensor& val, Tensor& grad, Tensor& m, Tensor& v, float wd){
         adamw_update(val, grad, m, v, grad.nelem(),
                      learning_rate, beta_1, beta_2, t, epsilon, wd, grad_scale, val.Scales, rng(), main_stream);
-        comm.reduce_abs_max(val.Scales);
     };
 
     run_update(Parameters->get_master_embeddings(), Grads->get_embeddings_shard(main_stream), opt_m.NonBlocks.Embeddings, opt_v.NonBlocks.Embeddings, weight_decay);
+    comm.reduce_max(Parameters->get_master_embeddings().Scales);
     run_update(Parameters->get_master_lnf_w(), Grads->get_lnf_w_shard(main_stream), opt_m.NonBlocks.LNF_w, opt_v.NonBlocks.LNF_w, 0.f);
+    comm.reduce_max(Parameters->get_master_lnf_w().Scales);
     CUDA_CHECK(cudaEventRecord(rs->OptEmbeddingsDone, main_stream));
 
     for(int i = 0; i < Config.NumLayers; i++) {
@@ -708,7 +709,8 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
         run_update(bw.MLP_Up_w, bg.MLP_Up_w, bm.MLP_Up_w, bv.MLP_Up_w, weight_decay);
         run_update(bw.MLP_Down_w, bg.MLP_Down_w, bm.MLP_Down_w, bv.MLP_Down_w, weight_decay);
-
+        auto scales = Parameters->get_scales_for_block(i);
+        comm.reduce_max(scales.first, scales.second - scales.first);
         Parameters->release_master_block(i, main_stream, rs->SideStream, *rs);
 
         CUDA_CHECK(cudaEventRecord(rs->LayerUpdateDone[i], main_stream));
@@ -716,6 +718,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
     if(!Config.TiedWordEmbeddings) {
         run_update(Parameters->get_master_lmhead(), Grads->get_lmhead_shard(main_stream), opt_m.NonBlocks.LMHead, opt_v.NonBlocks.LMHead, weight_decay);
+        comm.reduce_max(Parameters->get_master_lmhead().Scales);
     }
     comm.wait_on_comms(main_stream);
     CUDA_CHECK(cudaEventRecord(rs->OptimizerDone, main_stream));

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -710,7 +710,13 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         run_update(bw.MLP_Up_w, bg.MLP_Up_w, bm.MLP_Up_w, bv.MLP_Up_w, weight_decay);
         run_update(bw.MLP_Down_w, bg.MLP_Down_w, bm.MLP_Down_w, bv.MLP_Down_w, weight_decay);
         auto scales = Parameters->get_scales_for_block(i);
-        comm.reduce_max(scales.first, scales.second - scales.first);
+        // yes, we run this on main stream. Yes, this isn't nice because it prevents kernels from running in parallel.
+        // the communication is tiny, though, so it doesn't matter, and this setup guarantees that the abs-maxes are
+        // ready once we try to quantize on the main stream (which happens in `release_master_block`), so in that case
+        // we'd have to wait anyway.
+        // TODO there's probably a way to schedule this so that we can avoid this idle time. If it turns out to actually
+        //      matter (e.g., for small models), we can investigate more.
+        comm.reduce_max(scales.first, scales.second - scales.first, main_stream);
         Parameters->release_master_block(i, main_stream, rs->SideStream, *rs);
 
         CUDA_CHECK(cudaEventRecord(rs->LayerUpdateDone[i], main_stream));

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -55,6 +55,7 @@ template<class T>
 struct sLLamaBlockWeights;
 class LLamaWeightsManager;
 class LLamaGradsManager;
+class LLamaOptimizerStateManager;
 struct LLamaRunState;
 struct sLLamaWeights;
 class NCCLCommunicator;
@@ -113,8 +114,7 @@ private:
     LLamaOptions Options;
     std::shared_ptr<TensorAllocator> Allocator;
     std::unique_ptr<LLamaWeightsManager> Parameters;
-    std::unique_ptr<sLLamaWeights> OptM;
-    std::unique_ptr<sLLamaWeights> OptV;
+    std::unique_ptr<LLamaOptimizerStateManager> OptimizerState;
     std::unique_ptr<LLamaGradsManager> Grads;
     std::unique_ptr<LLamaRunState> RunState;
 

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2025, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#include "llama_optimizer.h"
+#include "llama_config.h"
+#include "llama_model.h"
+#include "utilities/comm.h"
+
+void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_stream) {
+    if(!mOffloadM && !mOffloadV) return;
+
+    int buffer = layer_idx % 2;
+    auto& stat = mStatus.at(buffer);
+    stat.LayerIdx = layer_idx;
+    stat.Fetch = false;
+
+    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, stat.DoneEvent, 0));
+
+    auto fetch = [fetch_stream, &stat](TensorShard& dst, TensorShard& src) {
+        // tensors on the same device are handled by pointer assignment
+        if(dst.Device == src.Device) {
+            dst.Data = src.Data;
+            dst.Scales = src.Scales;
+        } else {
+            CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyHostToDevice, fetch_stream));
+            dst.Scales = src.Scales;
+            stat.Fetch = true;
+        }
+    };
+
+    auto fetch_all = [&](sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& ref){
+        fetch(buf.LN1_w, ref.LN1_w);
+        fetch(buf.LN2_w, ref.LN2_w);
+        fetch(buf.Attn_QKV_w, ref.Attn_QKV_w);
+        fetch(buf.Attn_Out_w, ref.Attn_Out_w);
+        fetch(buf.MLP_Up_w, ref.MLP_Up_w);
+        fetch(buf.MLP_Down_w, ref.MLP_Down_w);
+        if (ref.Attn_QKV_b.has_value()) {
+            fetch(buf.Attn_QKV_b.value(), ref.Attn_QKV_b.value());
+        }
+    };
+
+    if(mOffloadM) {
+        auto& buf = mOptMBuffer.at(buffer);
+        auto& ref = mOptM.Blocks[layer_idx];
+
+        fetch_all(buf, ref);
+    }
+
+    if(mOffloadV) {
+        auto& buf = mOptVBuffer.at(buffer);
+        auto& ref = mOptV.Blocks[layer_idx];
+
+        fetch_all(buf, ref);
+    }
+
+    if(stat.Fetch) {
+        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
+    }
+}
+
+sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_m(int layer_idx, cudaStream_t stream) {
+    if(!mOffloadM) return mOptM.Blocks[layer_idx];
+    return get_block_from(layer_idx, stream, mOptMBuffer.at(layer_idx % 2));
+}
+
+sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_v(int layer_idx, cudaStream_t stream) {
+    if(!mOffloadV) return mOptV.Blocks[layer_idx];
+    return get_block_from(layer_idx, stream, mOptVBuffer.at(layer_idx % 2));
+}
+
+sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf) {
+    int buffer = layer_idx % 2;
+    auto& stat = mStatus.at(buffer);
+
+    if(stat.LayerIdx != layer_idx) {
+        throw std::logic_error("Layer index mismatch in get_block_from");
+    }
+
+    stat.Done = false;
+    // if we needed to fetch, we need to wait
+    if(stat.Fetch) {
+        CUDA_CHECK(cudaStreamWaitEvent(stream, stat.DoneEvent, 0));
+    }
+    stat.Fetch = false;
+
+    return buf;
+}
+
+void LLamaOptimizerStateManager::store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream)  {
+    int buffer = layer_idx % 2;
+    if(mOffloadM) {
+        store_one_block(layer_idx, stream, put_stream, mOptMBuffer[buffer], mOptM.Blocks[layer_idx]);
+    }
+
+    if(mOffloadV) {
+        store_one_block(layer_idx, stream, put_stream, mOptVBuffer[buffer], mOptV.Blocks[layer_idx]);
+    }
+
+    if(mOffloadM || mOffloadV) {
+        auto& stat = mStatus.at(layer_idx % 2);
+        if(stat.LayerIdx != layer_idx) {
+            throw std::logic_error("layer index mismatch in store_block");
+        }
+        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, put_stream));
+        stat.Done = true;
+    }
+}
+
+void LLamaOptimizerStateManager::store_one_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& dst) {
+
+
+    auto& stat = mStatus.at(layer_idx % 2);
+
+    auto send = [put_stream](TensorShard& dst, TensorShard& src) {
+        CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyDeviceToHost, put_stream));
+    };
+
+    // put stream can start as soon as the new master weights are ready
+    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
+
+    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
+
+    send(dst.LN1_w, buf.LN1_w);
+    send(dst.LN2_w, buf.LN2_w);
+    send(dst.Attn_QKV_w, buf.Attn_QKV_w);
+    send(dst.Attn_Out_w, buf.Attn_Out_w);
+    send(dst.MLP_Up_w, buf.MLP_Up_w);
+    send(dst.MLP_Down_w, buf.MLP_Down_w);
+    if (dst.Attn_QKV_b.has_value()) {
+        send(dst.Attn_QKV_b.value(), buf.Attn_QKV_b.value());
+    }
+}
+
+sLLamaNonBlockWeights<TensorShard>& LLamaOptimizerStateManager::non_block_m() {
+    return mOptM.NonBlocks;
+}
+
+sLLamaNonBlockWeights<TensorShard>& LLamaOptimizerStateManager::non_block_v() {
+    return mOptV.NonBlocks;
+}
+
+void zero_opt_state(sLLamaWeights& weights, cudaStream_t stream) {
+    // here's the first disadvantage of having individual buffers: We need to make a ton of memset calls
+    fill_zero(weights.NonBlocks.Embeddings, stream);
+    fill_zero(weights.NonBlocks.LNF_w, stream);
+    if(weights.NonBlocks.LMHead.Data != weights.NonBlocks.Embeddings.Data) {
+        fill_zero(weights.NonBlocks.LMHead, stream);
+    }
+    for(auto& layer: weights.Blocks) {
+        fill_zero(layer.LN1_w, stream);
+        fill_zero(layer.LN2_w, stream);
+        fill_zero(layer.Attn_QKV_w, stream);
+        if(auto& qkv_b = layer.Attn_QKV_b; qkv_b.has_value()) {
+            fill_zero(qkv_b.value(), stream);
+        }
+        fill_zero(layer.Attn_Out_w, stream);
+        fill_zero(layer.MLP_Up_w, stream);
+        fill_zero(layer.MLP_Down_w, stream);
+    }
+}
+
+LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc):
+    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV)
+{
+    {
+        auto ctx = alloc.with_context("Adam M");
+        EAllocationType alloc_type = options.OffloadOptM ? options.offload_alloc() : EAllocationType::ON_DEVICE;
+        LLamaConfig c = cfg;
+        c.DType = options.OptMomentumType;
+        mOptM = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
+        zero_opt_state(mOptM, stream);
+
+        if(options.OffloadOptM){
+            mOptMBuffer[0] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
+                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
+            mOptMBuffer[1] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
+                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
+        }
+    }
+
+    {
+        auto ctx = alloc.with_context("Adam V");
+        EAllocationType alloc_type = options.OffloadOptV ? options.offload_alloc() : EAllocationType::ON_DEVICE;
+        LLamaConfig c = cfg;
+        c.DType = options.OptVarianceType;
+        mOptV = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
+        zero_opt_state(mOptV, stream);
+        if(options.OffloadOptV){
+            mOptVBuffer[0] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
+                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
+            mOptVBuffer[1] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
+                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
+        }
+    }
+
+    if(options.OffloadOptM || options.OffloadOptV) {
+        mStatus[0] = sBufferStatus{-1, create_named_event("opt_fetch_0"), false, true};
+        mStatus[1] = sBufferStatus{-1, create_named_event("opt_fetch_1"), false, true};
+    }
+}

--- a/src/models/llama_optimizer.h
+++ b/src/models/llama_optimizer.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2025, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#ifndef LLMQ_SRC_MODELS_LLAMA_OPTIMIZER_H
+#define LLMQ_SRC_MODELS_LLAMA_OPTIMIZER_H
+
+#include "llama_weights.h"
+#include <array>
+
+class LLamaOptimizerStateManager {
+public:
+    LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc);
+    sLLamaNonBlockWeights<TensorShard>& non_block_m();
+    sLLamaNonBlockWeights<TensorShard>& non_block_v();
+
+    sLLamaWeights& full_m() { return mOptM; }
+    sLLamaWeights& full_v() { return mOptV; }
+
+    void fetch_block(int layer_idx, cudaStream_t fetch_stream);
+    sLLamaBlockWeights<TensorShard>& get_block_m(int layer_idx, cudaStream_t stream);
+    sLLamaBlockWeights<TensorShard>& get_block_v(int layer_idx, cudaStream_t stream);
+    void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
+private:
+    sLLamaWeights mOptM;
+    sLLamaWeights mOptV;
+    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptMBuffer;
+    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptVBuffer;
+
+    struct sBufferStatus {
+        int LayerIdx = -1;
+        cudaEvent_t DoneEvent = nullptr;
+        bool Fetch = false;
+        bool Done = true;
+    };
+
+    std::array<sBufferStatus, 2> mStatus;
+
+    bool mOffloadM;
+    bool mOffloadV;
+
+    sLLamaBlockWeights<TensorShard>& get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf);
+    void store_one_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& dst);
+};
+
+#endif //LLMQ_SRC_MODELS_LLAMA_OPTIMIZER_H

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -205,6 +205,14 @@ void LLamaWeightsManager::setup_scales(TensorAllocator& alloc) {
     }
 }
 
+
+std::pair<float*, float*> LLamaWeightsManager::get_scales_for_block(int layer_idx) {
+    float* abs_maxes = mAbsMaxes.get<float>();
+    float* begin = abs_maxes + 3 + layer_idx * 7;
+    return {begin + 0, begin + 7};
+}
+
+
 void LLamaWeightsManager::setup_master_buffers(const LLamaConfig& config, TensorAllocator& alloc) {
     if (mOffloadMaster) {
         for(int i = 0; i < 2; ++i) {
@@ -788,14 +796,14 @@ void LLamaWeightsManager::synchronize_absmax(NCCLCommunicator& comm) {
         if (layer.Attn_QKV_b.has_value()) {
             abs_max(layer.Attn_QKV_b.value().Scales, layer.Attn_QKV_b.value(), layer.Attn_QKV_b.value().nelem(), dp, nullptr);
         }
-        comm.reduce_abs_max(layer.LN1_w.Scales);
-        comm.reduce_abs_max(layer.LN2_w.Scales);
-        comm.reduce_abs_max(layer.Attn_QKV_w.Scales);
-        comm.reduce_abs_max(layer.Attn_Out_w.Scales);
-        comm.reduce_abs_max(layer.MLP_Up_w.Scales);
-        comm.reduce_abs_max(layer.MLP_Down_w.Scales);
+        comm.reduce_max(layer.LN1_w.Scales);
+        comm.reduce_max(layer.LN2_w.Scales);
+        comm.reduce_max(layer.Attn_QKV_w.Scales);
+        comm.reduce_max(layer.Attn_Out_w.Scales);
+        comm.reduce_max(layer.MLP_Up_w.Scales);
+        comm.reduce_max(layer.MLP_Down_w.Scales);
         if (layer.Attn_QKV_b.has_value()) {
-            comm.reduce_abs_max(layer.Attn_QKV_b.value().Scales);
+            comm.reduce_max(layer.Attn_QKV_b.value().Scales);
         }
         comm.wait_on_comms(nullptr);
     }

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -39,6 +39,40 @@ void allocate_matrix_params(sLLamaBlockWeights<T>& target, const LLamaConfig& co
     target.MLP_Down_w = alloc.allocate_shard(dtype, shard_idx, num_shards, "mlp_down_w", {C, H}, kind);
 }
 
+std::size_t aligned_size(std::size_t raw, int num_shards) {
+    return div_ceil(div_exact(raw, static_cast<std::size_t>(num_shards)), static_cast<std::size_t>(4096)) * 4096;
+}
+
+std::size_t bytes_for_block_matrices(const LLamaConfig& config, ETensorDType dtype, int num_shards) {
+    std::size_t C = config.HiddenSize;
+    std::size_t HS = config.head_size();
+
+    std::size_t total = 2 * aligned_size(C * get_dtype_size(dtype), num_shards);          // norms
+    long attn_intermediate_size = (config.NumQueryHeads + 2 * config.NumKeyValHeads) * HS;
+    if(config.UseQKVBias) {
+        total += aligned_size(attn_intermediate_size * get_dtype_size(dtype), num_shards); // QKV bias
+    }
+    return total;
+}
+
+std::size_t bytes_for_block_non_matrix(const LLamaConfig& config, ETensorDType dtype, int num_shards) {
+    std::size_t C = config.HiddenSize;
+    long H = config.IntermediateSize;
+    long HS = C / config.NumQueryHeads;
+    long attn_intermediate_size = (config.NumQueryHeads + 2 * config.NumKeyValHeads) * HS;
+
+    std::size_t total = 0;
+    total += aligned_size(attn_intermediate_size * C * get_dtype_size(dtype), num_shards); // QKV
+    total += aligned_size(C * C * get_dtype_size(dtype), num_shards); // out
+    total += aligned_size(2 * C * H * get_dtype_size(dtype), num_shards); // up
+    total += aligned_size(H * C * get_dtype_size(dtype), num_shards); // down
+    return total;
+}
+
+std::size_t bytes_for_block(const LLamaConfig& config, ETensorDType matrix_dtype, ETensorDType other_dtype, int num_shards) {
+    return bytes_for_block_non_matrix(config, other_dtype, num_shards) + bytes_for_block_matrices(config, matrix_dtype, num_shards);
+}
+
 sLLamaBlockWeights<Tensor> allocate_block_full(const LLamaConfig& config, ETensorDType matrix_dtype, ETensorDType other_dtype, EAllocationType kind, TensorAllocator& alloc) {
     sLLamaBlockWeights<Tensor> layer;
     allocate_matrix_params(layer, config, matrix_dtype, kind, 0, 1, alloc);
@@ -138,6 +172,8 @@ LLamaWeightsManager::LLamaWeightsManager(const LLamaConfig& config, const LLamaO
 
     mMaster.Blocks.reserve(config.NumLayers);
     mHeadID = config.TiedWordEmbeddings ? 0 : 1;
+
+    mOffloadMaster = options.OffloadMaster;
 }
 
 LLamaWeightsManager::~LLamaWeightsManager() {
@@ -169,6 +205,37 @@ void LLamaWeightsManager::setup_scales(TensorAllocator& alloc) {
     }
 }
 
+void LLamaWeightsManager::setup_master_buffers(const LLamaConfig& config, TensorAllocator& alloc) {
+    if (mOffloadMaster) {
+        for(int i = 0; i < 2; ++i) {
+            auto& buf = mMasterDeviceDoubleBuffer.at(i);
+            if (mWorkMatDType != mMasterDType) {
+                auto c = alloc.with_context("Master");
+                allocate_matrix_params(buf, config, mMasterDType, EAllocationType::ON_DEVICE, mShardIdx, mNumShards,
+                                       alloc);
+            } else {
+                // note: the actual data pointers will be overwritten before use, so this is safe
+                buf.Attn_QKV_w = mMaster.Blocks[0].Attn_QKV_w;
+                buf.Attn_Out_w = mMaster.Blocks[0].Attn_Out_w;
+                buf.MLP_Up_w = mMaster.Blocks[0].MLP_Up_w;
+                buf.MLP_Down_w = mMaster.Blocks[0].MLP_Down_w;
+            }
+
+            if (config.DType != mMasterDType) {
+                auto c = alloc.with_context("Master");
+                allocate_non_matrix_params(buf, config, mMasterDType, EAllocationType::ON_DEVICE, mShardIdx,
+                                           mNumShards, alloc);
+            } else {
+                buf.LN1_w = mMaster.Blocks[0].LN1_w;
+                buf.LN2_w = mMaster.Blocks[0].LN2_w;
+                buf.Attn_QKV_b = mMaster.Blocks[0].Attn_QKV_b;
+            }
+
+            mMasterDeviceBufferStatus.at(i) = sGatherData{i, create_named_event(("master_event_" + std::to_string(i)).c_str())};
+        }
+    }
+}
+
 void LLamaWeightsManager::invalidate() {
     ++mVersion;
 }
@@ -190,8 +257,81 @@ TensorShard& LLamaWeightsManager::get_master_lnf_w() {
     return mMaster.NonBlocks.LNF_w;
 }
 
-sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer_idx) {
-    return mMaster.Blocks[layer_idx];
+void LLamaWeightsManager::gather_master_block(int layer_idx, cudaStream_t fetch_stream) {
+    if(!mOffloadMaster) return;
+
+    int buffer = layer_idx % 2;
+    auto& buf = mMasterDeviceDoubleBuffer.at(buffer);
+    auto& stat = mMasterDeviceBufferStatus.at(buffer);
+    auto& ref = mMaster.Blocks[layer_idx];
+    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, stat.DoneEvent, 0));
+    stat.LayerIdx = layer_idx;
+    stat.Fetch = false;
+    auto fetch = [fetch_stream, &stat](TensorShard& dst, TensorShard& src) {
+        // tensors on the same device are handled by pointer assignment
+        if(dst.Device == src.Device) {
+            dst.Data = src.Data;
+            dst.Scales = src.Scales;
+        } else {
+            CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyHostToDevice, fetch_stream));
+            dst.Scales = src.Scales;
+            stat.Fetch = true;
+        }
+    };
+
+    fetch(buf.LN1_w, ref.LN1_w);
+    fetch(buf.LN2_w, ref.LN2_w);
+    fetch(buf.Attn_QKV_w, ref.Attn_QKV_w);
+    fetch(buf.Attn_Out_w, ref.Attn_Out_w);
+    fetch(buf.MLP_Up_w, ref.MLP_Up_w);
+    fetch(buf.MLP_Down_w, ref.MLP_Down_w);
+    if (ref.Attn_QKV_b.has_value()) {
+        fetch(buf.Attn_QKV_b.value(), ref.Attn_QKV_b.value());
+    }
+
+    if(stat.Fetch) {
+        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
+    }
+}
+
+sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer_idx, cudaStream_t stream) {
+    if(!mOffloadMaster) return mMaster.Blocks[layer_idx];
+
+    int buffer = layer_idx % 2;
+    auto& buf = mMasterDeviceDoubleBuffer.at(buffer);
+    auto& stat = mMasterDeviceBufferStatus.at(buffer);
+    update_get_status(stat, layer_idx, stream);
+    return buf;
+}
+
+void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t  put_stream) {
+    if(!mOffloadMaster) return;
+
+    int buffer = layer_idx % 2;
+    auto& buf = mMasterDeviceDoubleBuffer.at(buffer);
+    auto& stat = mMasterDeviceBufferStatus.at(buffer);
+    auto& ref = mMaster.Blocks[layer_idx];
+
+    auto send = [put_stream](TensorShard& dst, TensorShard& src) {
+        // tensors on the same device are handled by pointer assignment
+        if(dst.Device != src.Device) {
+            CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyDeviceToHost, put_stream));
+        }
+    };
+
+    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
+    send(ref.LN1_w, buf.LN1_w);
+    send(ref.LN2_w, buf.LN2_w);
+    send(ref.Attn_QKV_w, buf.Attn_QKV_w);
+    send(ref.Attn_Out_w, buf.Attn_Out_w);
+    send(ref.MLP_Up_w, buf.MLP_Up_w);
+    send(ref.MLP_Down_w, buf.MLP_Down_w);
+    if (ref.Attn_QKV_b.has_value()) {
+        send(ref.Attn_QKV_b.value(), buf.Attn_QKV_b.value());
+    }
+
+    release_status(stat, layer_idx, put_stream);
 }
 
 bool LLamaWeightsManager::is_in_cache(sGatherData& data, int expected) const {
@@ -251,7 +391,7 @@ void LLamaWeightsManager::convert_dtype_for_gather(TensorShard& src, TensorShard
 }
 
 void LLamaWeightsManager::gather_block(int layer_idx, NCCLCommunicator& comm, LLamaRunState& run_state) {
-    auto& src = get_master_block(layer_idx);
+    auto& src = mMaster.Blocks[layer_idx];
     auto& qnt = lookup_block_quants(layer_idx);
     auto& dst = lookup_block_weights(layer_idx);
     auto& gather_data = lookup_block_status(layer_idx);
@@ -426,7 +566,6 @@ private:
     sGatherData& lookup_block_status(int layer_idx) override;
 
     std::vector<sQuantBlock> mQuants;
-    bool mOffloadMaster = false;        // whether master copies of the weights (if they exist) should be offloaded to the CPU
 };
 
 WeightsMgrUnsharded::WeightsMgrUnsharded(const LLamaConfig& config, const LLamaOptions& options, int rank, int world, TensorAllocator& alloc) : LLamaWeightsManager(config, options, rank, world) {
@@ -461,6 +600,7 @@ WeightsMgrUnsharded::WeightsMgrUnsharded(const LLamaConfig& config, const LLamaO
     }
 
     setup_scales(alloc);
+    setup_master_buffers(config, alloc);
 }
 
 sLLamaBlockWeights<Tensor>& WeightsMgrUnsharded::lookup_block_weights(int layer_idx) {
@@ -493,7 +633,6 @@ private:
     sGatherData& lookup_block_status(int layer_idx) override;
 
     std::vector<sQuantBlock> mQuants;
-    bool mOffloadMaster = false;        // whether master copies of the weights (if they exist) should be offloaded to the CPU
     bool mPersistentQuants = false;     // whether to keep a quantized copy of the master shards
     bool mOffloadQuants = false;
 };
@@ -543,6 +682,7 @@ WeightsMgrSharded::WeightsMgrSharded(const LLamaConfig& config, const LLamaOptio
     }
 
     setup_scales(alloc);
+    setup_master_buffers(config, alloc);
 }
 
 sLLamaBlockWeights<Tensor>& WeightsMgrSharded::lookup_block_weights(int layer_idx) {

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -330,6 +330,10 @@ void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t strea
     auto& src = mMasterDeviceDoubleBuffer.at(buffer);
     auto& qnt = lookup_block_quants(layer_idx);
 
+    // put stream can start as soon as the new master weights are ready
+    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
+
     bool convert_any = false;
     if (qnt.LayerIdx == layer_idx) {
         NvtxRange q_rng("quantize");
@@ -342,12 +346,11 @@ void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t strea
         if (src.Attn_QKV_b.has_value()) {
             convert_dtype_for_gather(src.Attn_QKV_b.value(), qnt.Block.Attn_QKV_b.value(), convert_any, run_state);
         }
-        // indicate that this is alrady the version for the next step
+        // indicate that this is already the version for the next step
         qnt.Version = mVersion + 1;
     }
-
     CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
-    CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
+
     send(ref.LN1_w, buf.LN1_w);
     send(ref.LN2_w, buf.LN2_w);
     send(ref.Attn_QKV_w, buf.Attn_QKV_w);

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -706,8 +706,15 @@ WeightsMgrSharded::WeightsMgrSharded(const LLamaConfig& config, const LLamaOptio
             mQuants.push_back(sQuantBlock{allocate_block_shard(config, mWorkMatDType, config.DType, quant_alloc, mShardIdx, mNumShards, alloc), i});
         }
     } else {
-        for (int i = 0; i < 2; ++i) {
-            mQuants.push_back(sQuantBlock{shard_block(mWork.Blocks[i], mShardIdx, mNumShards)});
+        // TODO this should be more fine-grained; taking into account matrix and non-matrix parameters separately
+        if (mWorkMatDType == config.DType && mMasterDType == config.DType) {
+            for (int i = 0; i < config.NumLayers; ++i) {
+                mQuants.push_back(sQuantBlock{mMaster.Blocks[i], i, -1});
+            }
+        } else {
+            for (int i = 0; i < 2; ++i) {
+                mQuants.push_back(sQuantBlock{shard_block(mWork.Blocks[i], mShardIdx, mNumShards)});
+            }
         }
     }
 

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -257,7 +257,7 @@ TensorShard& LLamaWeightsManager::get_master_lnf_w() {
     return mMaster.NonBlocks.LNF_w;
 }
 
-void LLamaWeightsManager::gather_master_block(int layer_idx, cudaStream_t fetch_stream) {
+void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_stream) {
     if(!mOffloadMaster) return;
 
     int buffer = layer_idx % 2;

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -304,7 +304,7 @@ sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer
     return buf;
 }
 
-void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t  put_stream) {
+void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, LLamaRunState& run_state) {
     if(!mOffloadMaster) return;
 
     int buffer = layer_idx % 2;
@@ -318,6 +318,25 @@ void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t strea
             CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyDeviceToHost, put_stream));
         }
     };
+
+    auto& src = mMasterDeviceDoubleBuffer.at(buffer);
+    auto& qnt = lookup_block_quants(layer_idx);
+
+    bool convert_any = false;
+    if (qnt.LayerIdx == layer_idx) {
+        NvtxRange q_rng("quantize");
+        convert_dtype_for_gather(src.LN1_w, qnt.Block.LN1_w, convert_any, run_state);
+        convert_dtype_for_gather(src.LN2_w, qnt.Block.LN2_w, convert_any, run_state);
+        convert_dtype_for_gather(src.Attn_QKV_w, qnt.Block.Attn_QKV_w, convert_any, run_state);
+        convert_dtype_for_gather(src.Attn_Out_w, qnt.Block.Attn_Out_w, convert_any, run_state);
+        convert_dtype_for_gather(src.MLP_Up_w, qnt.Block.MLP_Up_w, convert_any, run_state);
+        convert_dtype_for_gather(src.MLP_Down_w, qnt.Block.MLP_Down_w, convert_any, run_state);
+        if (src.Attn_QKV_b.has_value()) {
+            convert_dtype_for_gather(src.Attn_QKV_b.value(), qnt.Block.Attn_QKV_b.value(), convert_any, run_state);
+        }
+        // indicate that this is alrady the version for the next step
+        qnt.Version = mVersion + 1;
+    }
 
     CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
     CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -71,7 +71,7 @@ public:
 
     void gather_master_block(int layer_idx, cudaStream_t fetch_stream);
     sLLamaBlockWeights<TensorShard>& get_master_block(int layer_idx, cudaStream_t stream);
-    void release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
+    void release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, LLamaRunState& run_state);
 
     // Weights that will be used during FWD/BWD
     void gather_embeddings(NCCLCommunicator& comm);

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -172,6 +172,12 @@ protected:
     bool mOffloadMaster;
 };
 
+class LLamaOptimizerParamManager {
+public:
+private:
+
+};
+
 sLLamaNonBlockWeights<Tensor> allocate_non_block_full(LLamaConfig config, ETensorDType dtype, EAllocationType kind, TensorAllocator& alloc);
 sLLamaNonBlockWeights<TensorShard> allocate_non_block_shard(LLamaConfig config, ETensorDType dtype, EAllocationType kind, int shard_idx, int num_shard, TensorAllocator& alloc);
 

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -63,6 +63,7 @@ public:
 
     void invalidate();
     void reset_scales(cudaStream_t stream);
+    std::pair<float*, float*> get_scales_for_block(int layer_idx);
 
     // Weight shards that get updated by the optimizer
     TensorShard& get_master_embeddings();

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -69,8 +69,33 @@ public:
     TensorShard& get_master_lmhead();
     TensorShard& get_master_lnf_w();
 
-    void gather_master_block(int layer_idx, cudaStream_t fetch_stream);
+    // In case non-offloaded weights, these functions are trivial no-ops and returns.
+    // If master weights are offloaded, then gather initiates the memcpy from host to
+    // device buffer (waiting if the buffer is still busy), get returns the buffer,
+    // with stream waiting on it being copied. Finally, release copies the buffer back
+    // to host using yet another stream (so we get efficient bidirectional communication).
+
+    //! Fetches the master weights from host in case of offloading. Does nothing otherwise.
+    //! \param layer_idx The layer for which master weights are requested
+    //! \param fetch_stream The stream on which to enqueue the H2D memcpy.
+    void fetch_master_block(int layer_idx, cudaStream_t fetch_stream);
+
+    //! Gets the master weights for the given block, making sure stream is blocked in case
+    //! they are being fetched from the host.
+    //! \param layer_idx The layer for which master weights are requested
+    //! \param stream The stream which to block until the preceding gather_master_block has completed.
     sLLamaBlockWeights<TensorShard>& get_master_block(int layer_idx, cudaStream_t stream);
+
+    //! Indicate that the optimizer has finished updating the master weight.
+    //! If they are not offloaded, this function does nothing.
+    //! Otherwise, if we use quantization and a quant buffer for this layer is available,
+    //! quantize the weights while they are still on the device.
+    //! Then copy these weights back to host using put_stream, and signal that the buffer can
+    //! be reused.
+    //! \param layer_idx The layer for which master weights are updated
+    //! \param stream The compute stream. Waits on this stream before the master weight is considered updated.
+    //! \param put_stream The stream on which to enqueue the H2D memcpy.
+    //! \param run_state The run state, needed to run `convert_dtype_for_gather`.
     void release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, LLamaRunState& run_state);
 
     // Weights that will be used during FWD/BWD

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -69,7 +69,9 @@ public:
     TensorShard& get_master_lmhead();
     TensorShard& get_master_lnf_w();
 
-    sLLamaBlockWeights<TensorShard>& get_master_block(int layer_idx);
+    void gather_master_block(int layer_idx, cudaStream_t fetch_stream);
+    sLLamaBlockWeights<TensorShard>& get_master_block(int layer_idx, cudaStream_t stream);
+    void release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
 
     // Weights that will be used during FWD/BWD
     void gather_embeddings(NCCLCommunicator& comm);
@@ -93,6 +95,7 @@ public:
 protected:
     LLamaWeightsManager(const LLamaConfig& config, const LLamaOptions& options, int rank, int world);
     void setup_scales(TensorAllocator& alloc);
+    void setup_master_buffers(const LLamaConfig& config, TensorAllocator& alloc);
 
     struct sGatherData {
         int LayerIdx = -1;
@@ -120,6 +123,9 @@ protected:
 
     Tensor mAbsMaxes;
 
+    std::array<sLLamaBlockWeights<TensorShard>, 2> mMasterDeviceDoubleBuffer;
+    std::array<sGatherData, 2> mMasterDeviceBufferStatus;
+
     bool is_in_cache(sGatherData& data, int expected) const;
     void update_get_status(sGatherData& data, int expected, cudaStream_t stream) const;
     void release_status(sGatherData& data, int expected, cudaStream_t stream);
@@ -136,6 +142,8 @@ protected:
 
     ETensorDType mMasterDType;
     ETensorDType mWorkMatDType;
+
+    bool mOffloadMaster;
 };
 
 sLLamaNonBlockWeights<Tensor> allocate_non_block_full(LLamaConfig config, ETensorDType dtype, EAllocationType kind, TensorAllocator& alloc);
@@ -149,5 +157,9 @@ sLLamaWeights allocate_weights(const LLamaConfig& config, EAllocationType kind, 
 
 sLLamaBlockWeights<TensorShard> shard_block(const sLLamaBlockWeights<Tensor>& block, int shard_idx, int num_shards);
 sLLamaNonBlockWeights<TensorShard> shard_non_block(const sLLamaNonBlockWeights<Tensor>& block, int shard_idx, int num_shards);
+
+std::size_t bytes_for_block(const LLamaConfig& config, ETensorDType matrix_dtype, ETensorDType other_dtype, int num_shards);
+std::size_t bytes_for_block_matrices(const LLamaConfig& config, ETensorDType dtype, int num_shards);
+std::size_t bytes_for_block_non_matrix(const LLamaConfig& config, ETensorDType dtype, int num_shards);
 
 #endif //LLMQ_LLAMA_WEIGHTS_H

--- a/src/utilities/comm.cpp
+++ b/src/utilities/comm.cpp
@@ -192,8 +192,8 @@ void NCCLCommunicator::reduce_loss(float* loss, cudaStream_t stream) {
     ncclCheck(ncclAllReduce(loss, loss, 1, ncclFloat, ncclAvg, mNcclComm, stream));
 }
 
-void NCCLCommunicator::reduce_max(float* values, int n) {
-    ncclCheck(ncclAllReduce(values, values, n, ncclFloat, ncclMax, mNcclComm, mCommsStream));
+void NCCLCommunicator::reduce_max(float* values, int n, cudaStream_t stream) {
+    ncclCheck(ncclAllReduce(values, values, n, ncclFloat, ncclMax, mNcclComm, stream ? stream : mCommsStream));
 }
 
 void NCCLCommunicator::reduce_norm(float* norm_squared, cudaStream_t stream) {

--- a/src/utilities/comm.cpp
+++ b/src/utilities/comm.cpp
@@ -192,8 +192,8 @@ void NCCLCommunicator::reduce_loss(float* loss, cudaStream_t stream) {
     ncclCheck(ncclAllReduce(loss, loss, 1, ncclFloat, ncclAvg, mNcclComm, stream));
 }
 
-void NCCLCommunicator::reduce_abs_max(float* abs_max) {
-    ncclCheck(ncclAllReduce(abs_max, abs_max, 1, ncclFloat, ncclMax, mNcclComm, mCommsStream));
+void NCCLCommunicator::reduce_max(float* values, int n) {
+    ncclCheck(ncclAllReduce(values, values, n, ncclFloat, ncclMax, mNcclComm, mCommsStream));
 }
 
 void NCCLCommunicator::reduce_norm(float* norm_squared, cudaStream_t stream) {

--- a/src/utilities/comm.h
+++ b/src/utilities/comm.h
@@ -53,7 +53,7 @@ public:
     void reduce_loss(float* loss, cudaStream_t stream);
     void reduce_norm(float* norm_squared, cudaStream_t stream);
 
-    void reduce_abs_max(float* abs_max);
+    void reduce_max(float* values, int n = 1);
 
     void wait_on_comms(cudaStream_t compute_stream);
 

--- a/src/utilities/comm.h
+++ b/src/utilities/comm.h
@@ -53,7 +53,7 @@ public:
     void reduce_loss(float* loss, cudaStream_t stream);
     void reduce_norm(float* norm_squared, cudaStream_t stream);
 
-    void reduce_max(float* values, int n = 1);
+    void reduce_max(float* values, int n = 1, cudaStream_t stream=nullptr);
 
     void wait_on_comms(cudaStream_t compute_stream);
 


### PR DESCRIPTION
While it is possible to directly access cudaMallocHost values from a kernel, doing so results in suboptimal PCIe utilization.
With these changes, we allocate an additional 2 layer buffers to double-buffer streaming data from host -> device -> host with cudaMemcpy.
As an additional benefit, we can run quantization _before_ moving data back to host (actually, the copy and quant could even overlap, since the copy is just reading... I don't think there's much gain from that, though, and it would complicate the cudaEvent setup a bit)

Right now, we're _not_ doing this for embeddings/lmhead. There are two reasons. First, allocating the additional buffers would be quite expensive, as these layers are huge. Second, for the embeddings, they are at the beginning of the optimizer step, so we'd actually get the full delay of the first, huge memcpy, before we could start running the update.
With the current code, the first two layers' master params are fetched in parallel to the embedding optimizer step, so it's not too bad.