### PR TITLE
Offload residual activations

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -121,7 +121,7 @@ jobs:
           - name: "Determinism test"
             args: ""
           - name: "Full Block"
-            args: "--recompute-block --offload-residual"
+            args: "--recompute-block --offload-residual --use-cuda-graphs"
           - name: "Blockwise"
             args: "--recompute-att --recompute-ffn"
           - name: "Non-linearities"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -115,13 +115,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         recompute:
           - name: "Determinism test"
             args: ""
           - name: "Full Block"
-            args: "--recompute-block"
+            args: "--recompute-block --offload-residual"
           - name: "Blockwise"
             args: "--recompute-att --recompute-ffn"
           - name: "Non-linearities"
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         config:
           - name: "LLMQ BF16"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ Additional memory savings, especially for larger models, can be achieved by the 
 - `--recompute-ffn` - Recompute the entire feed-forward block during backward pass (implies --recompute-swiglu).
 - `--recompute-qkv` - Recompute QKV projections during backward pass.
 - `--recompute-att` - Recompute the entire attention block during backward pass (implies --recompute-qkv).
+- `--recompute-block` - Recompute the entire transformer block during backward pass (subsumes the other recompute flags).
+- `--offload-residuals` - Offload the residuals (of the ffn block; the only remaining part of the block that is not recomputed) to pinned host memory. Combined with `--recompute-block`, the total activation memory consumption becomes independent of the network depth.
+- `--lmhead-chunks=N` - Split LM-head computation into `N` chunks, so that the required size of the logit tensor is reduced by a factor of `N`.
 
 ### Multi-GPU
 - `--gpus <int>` - Number of GPUs to use. If 0, uses all available GPUs.
@@ -374,8 +377,8 @@ All settings use `--lmhead-chunks=${BATCH_SIZE}`
 | Qwen2.5-3B¹⁰  | 4    | bf16  | 4     | 25k  | 71% | 11h   |
 | Qwen2.5-7B⁶   | 4    | fp8   | 16    | 16k  | 57% | 17h   |
 | Qwen2.5-7B⁷   | 4    | bf16  | 16    | 9.3k | 61% | 30h   |
-| Qwen2.5-14B⁸  | 4    | fp8   | 8     | 7.3k | 51% | 38h   |
-| Qwen2.5-14B⁹  | 4    | bf16  | 8     | 3.5k | 46% | 78h   |
+| Qwen2.5-14B⁸  | 4    | fp8   | 16    | 7.8k | 54% | 36h   |
+| Qwen2.5-14B⁹  | 4    | bf16  | 16    | 5.1k | 66% | 54h   |
 
 
 ^1: `--offload-opt-m --offload-opt-v --recompute-swiglu --offload-master`  
@@ -385,8 +388,8 @@ All settings use `--lmhead-chunks=${BATCH_SIZE}`
 ^5: `--recompute-norm --recompute-swiglu` 
 ^6: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
 ^7: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --recompute-att --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce` 
-^8: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
-^9: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce`  
+^8: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --offload-residual --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce --persistent-quants --offload-quants`  
+^9: `--offload-opt-m --offload-opt-v --recompute-block --offload-master --offload-residual --shard-weights --memcpy-all-gather --shard-gradients --memcpy-send-recv --all-to-all-reduce`  
 ^10: `--offload-opt-m --recompute-swiglu --recompute-norm`
 
 ### L40S

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -176,7 +176,7 @@ NB_MODULE(_pyllmq, m) {
 
     nb::class_<LLamaOptions>(m, "LLamaOptions")
         .def("__init__", [](LLamaOptions *t, bool recompute_swiglu, bool recompute_rmsnorm,
-            bool recompute_ffn, bool recompute_qkv, bool recompute_att, bool recompute_block,
+            bool recompute_ffn, bool recompute_qkv, bool recompute_att, bool recompute_block, bool offload_residual,
             bool use_cuda_graphs,
             bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v,
             bool use_write_combined, bool shard_weights, bool persistent_quants, bool shard_gradients, bool use_all_to_all_reduce,
@@ -189,6 +189,7 @@ NB_MODULE(_pyllmq, m) {
                 .RecomputeQKV = recompute_qkv,
                 .RecomputeAtt = recompute_att,
                 .RecomputeBlock = recompute_block,
+                .OffloadResidual = offload_residual,
                 .LMHeadChunks = lmhead_chunks,
                 .UseCudaGraphs = use_cuda_graphs,
                 .OffloadMaster = offload_master,
@@ -210,6 +211,7 @@ NB_MODULE(_pyllmq, m) {
              nb::arg("recompute_swiglu") = false, nb::arg("recompute_rmsnorm") = false,
              nb::arg("recompute_ffn") = false,    nb::arg("recompute_qkv") = false,
              nb::arg("recompute_att") = false,    nb::arg("recompute_block") = false,
+             nb::arg("offload_residual") = false,
              nb::arg("use_cuda_graphs") = true,   nb::arg("offload_master") = false,
              nb::arg("offload_quants") = false,   nb::arg("offload_opt_m") = false,
              nb::arg("offload_opt_v") = false,    nb::arg("use_write_combined") = false,
@@ -225,6 +227,7 @@ NB_MODULE(_pyllmq, m) {
         .def_rw("recompute_qkv", &LLamaOptions::RecomputeQKV)
         .def_rw("recompute_att", &LLamaOptions::RecomputeAtt)
         .def_rw("recompute_block", &LLamaOptions::RecomputeBlock)
+        .def_rw("offload_residual", &LLamaOptions::OffloadResidual)
         .def_rw("lmhead_chunks", &LLamaOptions::LMHeadChunks)
         .def_rw("use_cuda_graphs", &LLamaOptions::UseCudaGraphs)
         .def_rw("offload_master", &LLamaOptions::OffloadMaster)

--- a/src/binding/python/tests/run.py
+++ b/src/binding/python/tests/run.py
@@ -44,6 +44,7 @@ class RunConfig:
     recompute_qkv: bool = False
     recompute_att: bool = False
     recompute_block: bool = False
+    offload_residual: bool = False
     use_cuda_graphs: bool = False
 
     # offloading
@@ -116,6 +117,7 @@ def _create_options(config: RunConfig) -> pyllmq.LLamaOptions:
     options.momentum_type = config.opt_m_dtype
     options.variance_type = config.opt_v_dtype
     options.lmhead_chunks = config.lmhead_chunks
+    options.offload_residual = config.offload_residual
 
     options.offload_opt_m = config.offload_opt_m
     options.offload_opt_v = config.offload_opt_v
@@ -226,6 +228,8 @@ def parse_args(args: list = None) -> RunConfig:
                         help="Recompute attention block during backward pass")
     parser.add_argument("--recompute-block", action="store_true",
                         help="Recompute entire transformer block")
+    parser.add_argument("--offload-residual", action="store_true",
+                        help="Offload residual activations")
     parser.add_argument("--use-cuda-graphs", action="store_true",
                         help="Enable CUDA graphs")
 
@@ -281,5 +285,6 @@ def parse_args(args: list = None) -> RunConfig:
         recompute_qkv=args.recompute_qkv,
         recompute_att=args.recompute_att,
         recompute_block=args.recompute_block,
+        offload_residual=args.offload_residual,
         use_cuda_graphs=args.use_cuda_graphs,
     )

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -425,6 +425,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
 
     Parameters->release_lnf(main_stream);
     Grads->notify_lnf_w(main_stream, comm);
+    rs->fetch_res_ffn(L-2, comm.stream());
     Parameters->gather_block(L - 1, comm, *rs);
     // now backward all the layers
     for (int l = L-1; l >= 0; l--) {
@@ -432,22 +433,23 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         auto& dw = Grads->get_block_full(l, main_stream, comm, accumulate);
 
         // prefetch previous layer
+        if(l > 1) {
+            rs->fetch_res_ffn(l-2, comm.stream());
+        }
         if(l > 0) {
             Parameters->gather_block(l - 1, comm, *rs);
         }
+
         auto& weights = Parameters->get_block(l, main_stream);
 
         // last layer changes topology, so for now just don't use graph
         trace_or_execute_cuda_graph([&]() {
-            if(l > 0) {
-                rs->fetch_res_ffn(l-1, comm.stream());
-            }
             _recompute_block(l, weights);
             _backward_block(l, accumulate, weights, dw);
-            if(l > 0) {
-                rs->release_res_ffn(l - 1, main_stream);
-            }
             }, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
+        if(l > 0) {
+            rs->release_res_ffn(l - 1, main_stream);
+        }
         Parameters->release_block(l, main_stream);
         Grads->notify_block(l, main_stream, comm);
     }

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -130,29 +130,18 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         trace_or_execute_cuda_graph([&](){_forward_block(l, wgt);},
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
-        if(Options.OffloadResidual && l > 0) {
-            CUDA_CHECK(cudaStreamWaitEvent(comm.stream(), rs->OffloadResidualEvent, 0));
-            CUDA_CHECK(cudaMemcpyAsync(rs->OffloadedResiduals.at(l-1).Data, rs->Acts.at(l-1).ResidualFFN.Data,
-                                       rs->Acts.at(l-1).ResidualFFN.bytes(), cudaMemcpyDeviceToHost, comm.stream()));
-            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
+        if(l > 0) {
+            rs->put_res_ffn(l-1, comm.stream());
         }
     }
-
-    if (Options.OffloadResidual)
-        CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
 
     {
         auto& acts = rs->Acts[Config.NumLayers-1];
         Parameters->gather_lnf(comm);
-        fused_residual_rmsnorm_forward(acts.ResidualFFN, rs->LNF, rs->LNF_Rstd, acts.ResidualAtt,
+        fused_residual_rmsnorm_forward(rs->get_res_ffn(Config.NumLayers - 1, main_stream), rs->LNF, rs->LNF_Rstd, acts.ResidualAtt,
                                        acts.MlpDown, Parameters->get_lnf(main_stream), nullptr, Config.RmsNormEps, B * T, C, main_stream);
         Parameters->release_lnf(main_stream);
-
-        if(Options.OffloadResidual) {
-            CUDA_CHECK(cudaMemcpyAsync(rs->OffloadedResiduals.at(Config.NumLayers-1).Data, acts.ResidualFFN.Data,
-                                       acts.ResidualFFN.bytes(), cudaMemcpyDeviceToHost, main_stream));
-            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
-        }
+        rs->put_res_ffn(Config.NumLayers-1, comm.stream());
     }
 
     // do not return before inputs can be accessed again.
@@ -173,7 +162,7 @@ void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
     long Hs = Config.head_size();
     cudaStream_t main_stream = rs->MainStream;
 
-    Tensor residual = l == 0 ? rs->Encoded : rs->Acts[l - 1].ResidualFFN;
+    Tensor residual = l == 0 ? rs->Encoded : rs->get_res_ffn(l-1, main_stream);
 
     auto& acts = rs->Acts[l];
 
@@ -185,16 +174,11 @@ void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
                         quant_abs_max_ptr(rs->Acts[0].LN1), Config.RmsNormEps, B, T, C, main_stream);
     } else {
         auto& prev = rs->Acts[l-1];
-        if(Options.OffloadResidual) {
-            CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
-        }
-        fused_residual_rmsnorm_forward(prev.ResidualFFN, acts.LN1.Value, acts.LN1_Rstd,
+        fused_residual_rmsnorm_forward(rs->get_res_ffn(l-1, main_stream), acts.LN1.Value, acts.LN1_Rstd,
                                        prev.ResidualAtt, prev.MlpDown, weights.LN1_w,
                                        quant_abs_max_ptr(acts.LN1),
                                        Config.RmsNormEps, B * T, C, main_stream);
-        if(Options.OffloadResidual) {
-            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
-        }
+        rs->release_res_ffn(l-1, main_stream);
     }
 
     // 1) projection to QKV vectors (note k,v may be fewer heads than q)
@@ -436,10 +420,9 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     Parameters->gather_lnf(comm);
     // backward the final layernorm
     rmsnorm_backward(d_acts[L-1].DResFFN.Value, d_lnf_w, rs->RMSNormScratch, d_acts[L - 1].DResFFN.Value, rs->DLNF,
-                     rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, quant_abs_max_ptr(d_acts[L-1].DResFFN), B, T, C, rs->DeviceProp, main_stream);
-    if(Options.OffloadResidual) {
-        CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
-    }
+                     rs->get_res_ffn(L-1, main_stream), Parameters->get_lnf(main_stream), rs->LNF_Rstd, quant_abs_max_ptr(d_acts[L-1].DResFFN), B, T, C, rs->DeviceProp, main_stream);
+    rs->release_res_ffn(L-1, main_stream);
+
     Parameters->release_lnf(main_stream);
     Grads->notify_lnf_w(main_stream, comm);
     Parameters->gather_block(L - 1, comm, *rs);
@@ -453,20 +436,17 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
             Parameters->gather_block(l - 1, comm, *rs);
         }
         auto& weights = Parameters->get_block(l, main_stream);
+
         // last layer changes topology, so for now just don't use graph
         trace_or_execute_cuda_graph([&]() {
-            if(Options.OffloadResidual && l > 0) {
-                CUDA_CHECK(cudaStreamWaitEvent(comm.stream(), rs->OffloadResidualEvent, 0));
-                CUDA_CHECK(cudaMemcpyAsync(rs->Acts.at(l-1).ResidualFFN.Data, rs->OffloadedResiduals.at(l-1).Data,
-                                           rs->Acts.at(l-1).ResidualFFN.bytes(), cudaMemcpyHostToDevice, comm.stream()));
-                CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
-                CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
+            if(l > 0) {
+                rs->fetch_res_ffn(l-1, comm.stream());
             }
             _recompute_block(l, weights);
             _backward_block(l, accumulate, weights, dw);
-            if(Options.OffloadResidual) {
-               CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
-           }
+            if(l > 0) {
+                rs->release_res_ffn(l - 1, main_stream);
+            }
             }, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
         Parameters->release_block(l, main_stream);
         Grads->notify_block(l, main_stream, comm);
@@ -510,7 +490,7 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
 
     // Attention block
     if(recompute_ln1) {
-        Tensor& residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
+        Tensor residual = layer == 0 ? rs->Encoded : rs->get_res_ffn(layer - 1, main_stream);
         rmsnorm_forward(acts.LN1.Value, acts.LN1_Rstd, residual, weights.LN1_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
     }
 
@@ -541,7 +521,7 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
     // Feed-forward block
     if(recompute_ln2) {
         if (opt.RecomputeBlock) {
-            Tensor residual = layer == 0 ? rs->Encoded : rs->Acts[layer - 1].ResidualFFN;
+            Tensor residual = layer == 0 ? rs->Encoded : rs->get_res_ffn(layer - 1, main_stream);
             fused_residual_rmsnorm_forward(acts.ResidualAtt, acts.LN2.Value, acts.LN2_Rstd, residual, acts.AttO, weights.LN2_w,
                                  nullptr, Config.RmsNormEps, B * T, C, main_stream);
         } else {
@@ -612,7 +592,8 @@ void LLamaModel::_backward_block(int layer, bool accumulate, sLLamaBlockWeights<
     if(layer > 0) {
         auto& prev_dacts = rs->DActs.at(layer - 1);
         rmsnorm_backward(prev_dacts.DResFFN.Value, d_weights.LN1_w, rs->RMSNormScratch, prev_dacts.DResAtt.Value, d_acts.DLN1,
-                         rs->Acts[layer - 1].ResidualFFN, weights.LN1_w, acts.LN1_Rstd, quant_abs_max_ptr(prev_dacts.DResFFN), B, T, C, rs->DeviceProp, main_stream);
+                         rs->get_res_ffn(layer-1, main_stream), weights.LN1_w, acts.LN1_Rstd, quant_abs_max_ptr(prev_dacts.DResFFN),
+                         B, T, C, rs->DeviceProp, main_stream);
     } else {
         rmsnorm_backward(rs->DEmb, d_weights.LN1_w, rs->RMSNormScratch, d_acts.DResAtt.Value, d_acts.DLN1,
                          rs->Encoded, weights.LN1_w, acts.LN1_Rstd, nullptr, B, T, C, rs->DeviceProp, main_stream);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -131,7 +131,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
         if(l > 0) {
-            rs->put_res_ffn(l-1, comm.stream());
+            rs->put_res_ffn(l-1, rs->SideStream);
         }
     }
 
@@ -141,7 +141,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         fused_residual_rmsnorm_forward(rs->get_res_ffn(Config.NumLayers - 1, main_stream), rs->LNF, rs->LNF_Rstd, acts.ResidualAtt,
                                        acts.MlpDown, Parameters->get_lnf(main_stream), nullptr, Config.RmsNormEps, B * T, C, main_stream);
         Parameters->release_lnf(main_stream);
-        rs->put_res_ffn(Config.NumLayers-1, comm.stream());
+        rs->put_res_ffn(Config.NumLayers-1, rs->SideStream);
     }
 
     // do not return before inputs can be accessed again.

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -127,7 +127,24 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         }
 
         auto& wgt = Parameters->get_block(l, main_stream);
-        trace_or_execute_cuda_graph([&](){_forward_block(l, wgt);},
+        Tensor residual = l == 0 ? rs->Encoded : rs->get_res_ffn(l-1, main_stream);
+
+        // fuse RMSNorm with residual, except in the first layer when no residual exists yet.
+        // mark_res_ffn_ready records an event, and we need to wait for that event outside the
+        // graph, so this block has to be separate.
+        if (l == 0) {
+            rmsnorm_forward(rs->Acts[0].LN1.Value, rs->Acts[0].LN1_Rstd, residual, wgt.LN1_w,
+                            quant_abs_max_ptr(rs->Acts[0].LN1), Config.RmsNormEps, B, T, C, main_stream);
+        } else {
+            auto& prev = rs->Acts[l-1];
+            fused_residual_rmsnorm_forward(residual, rs->Acts[l].LN1.Value, rs->Acts[l].LN1_Rstd,
+                                           prev.ResidualAtt, prev.MlpDown, wgt.LN1_w,
+                                           quant_abs_max_ptr(rs->Acts[l].LN1),
+                                           Config.RmsNormEps, B * T, C, main_stream);
+            rs->mark_res_ffn_ready(l-1, main_stream);
+        }
+
+        trace_or_execute_cuda_graph([&](){_forward_block(l, wgt, residual);},
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
         if(l > 0) {
@@ -141,6 +158,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         fused_residual_rmsnorm_forward(rs->get_res_ffn(Config.NumLayers - 1, main_stream), rs->LNF, rs->LNF_Rstd, acts.ResidualAtt,
                                        acts.MlpDown, Parameters->get_lnf(main_stream), nullptr, Config.RmsNormEps, B * T, C, main_stream);
         Parameters->release_lnf(main_stream);
+        rs->mark_res_ffn_ready(Config.NumLayers-1, main_stream);
         rs->put_res_ffn(Config.NumLayers-1, rs->SideStream);
     }
 
@@ -149,7 +167,7 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
     CUDA_CHECK(cudaEventRecord(rs->ForwardDone, main_stream));
 }
 
-void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
+void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights, Tensor& residual)
 {
     auto& rs = RunState;
     int l = layer;
@@ -162,24 +180,7 @@ void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
     long Hs = Config.head_size();
     cudaStream_t main_stream = rs->MainStream;
 
-    Tensor residual = l == 0 ? rs->Encoded : rs->get_res_ffn(l-1, main_stream);
-
     auto& acts = rs->Acts[l];
-
-    // fuse RMSNorm with residual, except in the first layer when no residual exists yet.
-    // note that there is a unified kernel for fused/unfused rmsnorm, so this condition
-    // is in fact safe to use during graph capture.
-    if (l == 0) {
-        rmsnorm_forward(rs->Acts[0].LN1.Value, rs->Acts[0].LN1_Rstd, rs->Encoded, weights.LN1_w,
-                        quant_abs_max_ptr(rs->Acts[0].LN1), Config.RmsNormEps, B, T, C, main_stream);
-    } else {
-        auto& prev = rs->Acts[l-1];
-        fused_residual_rmsnorm_forward(rs->get_res_ffn(l-1, main_stream), acts.LN1.Value, acts.LN1_Rstd,
-                                       prev.ResidualAtt, prev.MlpDown, weights.LN1_w,
-                                       quant_abs_max_ptr(acts.LN1),
-                                       Config.RmsNormEps, B * T, C, main_stream);
-        rs->release_res_ffn(l-1, main_stream);
-    }
 
     // 1) projection to QKV vectors (note k,v may be fewer heads than q)
     forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
@@ -441,10 +442,9 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         }
 
         auto& weights = Parameters->get_block(l, main_stream);
-
-        // last layer changes topology, so for now just don't use graph
+        Tensor residual = l == 0 ? rs->Encoded : rs->get_res_ffn(l - 1, main_stream);
         trace_or_execute_cuda_graph([&]() {
-            _recompute_block(l, weights);
+            _recompute_block(l, weights, residual);
             _backward_block(l, accumulate, weights, dw);
             }, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
         if(l > 0) {
@@ -467,7 +467,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     CUDA_CHECK(cudaEventSynchronize(rs->TransferDone));
 }
 
-void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights) {
+void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights, Tensor& residual) {
     NvtxRange classifier_and_loss_range("recompute");
     auto& rs = RunState;
     cudaStream_t main_stream = rs->MainStream;
@@ -492,7 +492,6 @@ void LLamaModel::_recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights
 
     // Attention block
     if(recompute_ln1) {
-        Tensor residual = layer == 0 ? rs->Encoded : rs->get_res_ffn(layer - 1, main_stream);
         rmsnorm_forward(acts.LN1.Value, acts.LN1_Rstd, residual, weights.LN1_w, nullptr, Config.RmsNormEps, B, T, C, main_stream);
     }
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -130,7 +130,16 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         trace_or_execute_cuda_graph([&](){_forward_block(l, wgt);},
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
+        if(Options.OffloadResidual && l > 0) {
+            CUDA_CHECK(cudaStreamWaitEvent(comm.stream(), rs->OffloadResidualEvent, 0));
+            CUDA_CHECK(cudaMemcpyAsync(rs->OffloadedResiduals.at(l-1).Data, rs->Acts.at(l-1).ResidualFFN.Data,
+                                       rs->Acts.at(l-1).ResidualFFN.bytes(), cudaMemcpyDeviceToHost, comm.stream()));
+            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
+        }
     }
+
+    if (Options.OffloadResidual)
+        CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
 
     {
         auto& acts = rs->Acts[Config.NumLayers-1];
@@ -138,6 +147,12 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
         fused_residual_rmsnorm_forward(acts.ResidualFFN, rs->LNF, rs->LNF_Rstd, acts.ResidualAtt,
                                        acts.MlpDown, Parameters->get_lnf(main_stream), nullptr, Config.RmsNormEps, B * T, C, main_stream);
         Parameters->release_lnf(main_stream);
+
+        if(Options.OffloadResidual) {
+            CUDA_CHECK(cudaMemcpyAsync(rs->OffloadedResiduals.at(Config.NumLayers-1).Data, acts.ResidualFFN.Data,
+                                       acts.ResidualFFN.bytes(), cudaMemcpyDeviceToHost, main_stream));
+            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
+        }
     }
 
     // do not return before inputs can be accessed again.
@@ -170,10 +185,16 @@ void LLamaModel::_forward_block(int layer, sLLamaBlockWeights<Tensor>& weights)
                         quant_abs_max_ptr(rs->Acts[0].LN1), Config.RmsNormEps, B, T, C, main_stream);
     } else {
         auto& prev = rs->Acts[l-1];
+        if(Options.OffloadResidual) {
+            CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
+        }
         fused_residual_rmsnorm_forward(prev.ResidualFFN, acts.LN1.Value, acts.LN1_Rstd,
                                        prev.ResidualAtt, prev.MlpDown, weights.LN1_w,
                                        quant_abs_max_ptr(acts.LN1),
                                        Config.RmsNormEps, B * T, C, main_stream);
+        if(Options.OffloadResidual) {
+            CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
+        }
     }
 
     // 1) projection to QKV vectors (note k,v may be fewer heads than q)
@@ -416,9 +437,11 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
     // backward the final layernorm
     rmsnorm_backward(d_acts[L-1].DResFFN.Value, d_lnf_w, rs->RMSNormScratch, d_acts[L - 1].DResFFN.Value, rs->DLNF,
                      rs->Acts[L - 1].ResidualFFN, Parameters->get_lnf(main_stream), rs->LNF_Rstd, quant_abs_max_ptr(d_acts[L-1].DResFFN), B, T, C, rs->DeviceProp, main_stream);
+    if(Options.OffloadResidual) {
+        CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
+    }
     Parameters->release_lnf(main_stream);
     Grads->notify_lnf_w(main_stream, comm);
-
     Parameters->gather_block(L - 1, comm, *rs);
     // now backward all the layers
     for (int l = L-1; l >= 0; l--) {
@@ -431,9 +454,19 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         }
         auto& weights = Parameters->get_block(l, main_stream);
         // last layer changes topology, so for now just don't use graph
-        trace_or_execute_cuda_graph([&](){
+        trace_or_execute_cuda_graph([&]() {
+            if(Options.OffloadResidual && l > 0) {
+                CUDA_CHECK(cudaStreamWaitEvent(comm.stream(), rs->OffloadResidualEvent, 0));
+                CUDA_CHECK(cudaMemcpyAsync(rs->Acts.at(l-1).ResidualFFN.Data, rs->OffloadedResiduals.at(l-1).Data,
+                                           rs->Acts.at(l-1).ResidualFFN.bytes(), cudaMemcpyHostToDevice, comm.stream()));
+                CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, comm.stream()));
+                CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->OffloadResidualEvent, 0));
+            }
             _recompute_block(l, weights);
             _backward_block(l, accumulate, weights, dw);
+            if(Options.OffloadResidual) {
+               CUDA_CHECK(cudaEventRecord(rs->OffloadResidualEvent, main_stream));
+           }
             }, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs && l != 0);
         Parameters->release_block(l, main_stream);
         Grads->notify_block(l, main_stream, comm);

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -107,8 +107,8 @@ protected:
     void _calculate_gradient_norm(NCCLCommunicator& comm, float grad_clip);
     void _reduce_loss(LLamaRunState& acts, NCCLCommunicator& comm, int B, int T);
 
-    void _forward_block(int layer, sLLamaBlockWeights<Tensor>& weights);
-    void _recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights);
+    void _forward_block(int layer, sLLamaBlockWeights<Tensor>& weights, Tensor& residual);
+    void _recompute_block(int layer, sLLamaBlockWeights<Tensor>& weights, Tensor& residual);
     void _backward_block(int layer, bool accumulate, sLLamaBlockWeights<Tensor>& weights, sLLamaGradBlock& grads);
 private:
     LLamaConfig Config;

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -25,6 +25,7 @@ struct LLamaOptions {
     bool RecomputeQKV = false;
     bool RecomputeAtt = false;
     bool RecomputeBlock = false;
+    bool OffloadResidual = false;
     int LMHeadChunks = 1;
     bool UseCudaGraphs = false;
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -92,7 +92,6 @@ LLamaRunState::LayerActivations RunStateBuilder::allocate_basic_fwd_tensors(Tens
 
     Tensor qkv = allocate_or_reuse(Options.RecomputeQKV, tQKVBuffer, Config.DType, "qkv", B, T, Config.qkv_channels());
     Tensor res_att = allocate_or_reuse(Options.RecomputeBlock, tResAttBuffer, Config.DType, "res_att", B, T, C);
-    Tensor res_ffn = allocate_or_reuse(Options.OffloadResidual, tFFNResBuffer, Config.DType, "res_ffn", B, T, C);
     Tensor lse = allocate(ETensorDType::FP32, "lse", B, T, Config.NumQueryHeads);
     Tensor att_v = allocate_or_reuse(Options.RecomputeAtt, tAttBuffer, Config.DType, "att_v", B, T, C);
     // not needed for backward, so can reuse an existing buffer
@@ -112,7 +111,7 @@ LLamaRunState::LayerActivations RunStateBuilder::allocate_basic_fwd_tensors(Tens
     Tensor rope = allocate_or_reuse(true, qkv, Config.DType, "rope", B, T, Config.qkv_channels());
 
     return LLamaRunState::LayerActivations{ln1_rstd, ln1, ln2_rstd, ln2, qkv, lse, rope, att, atto,
-                                           res_att, mlp_up, mlp_down, swiglu, res_ffn};
+                                           res_att, mlp_up, mlp_down, swiglu};
 }
 
 void RunStateBuilder::allocate_fwd_quant_tensors(LLamaRunState::LayerActivations& act) {
@@ -192,6 +191,44 @@ std::vector<LLamaRunState::LayerGradients> RunStateBuilder::allocate_backward_bu
     return LGrads;
 }
 
+void LLamaRunState::fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream) {
+    if(!Options.OffloadResidual) {
+        return;
+    }
+
+    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, OffloadResidualEvent, 0));
+    CUDA_CHECK(cudaMemcpyAsync(DeviceResiduals.at(0).Data, OffloadedResiduals.at(layer_idx).Data,
+                               DeviceResiduals.at(0).bytes(), cudaMemcpyHostToDevice, fetch_stream));
+    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, fetch_stream));
+}
+
+void LLamaRunState::put_res_ffn(int layer_idx, cudaStream_t put_stream) {
+    if(!Options.OffloadResidual) {
+        return;
+    }
+
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, OffloadResidualEvent, 0));
+    CUDA_CHECK(cudaMemcpyAsync(OffloadedResiduals.at(layer_idx).Data, DeviceResiduals.at(0).Data,
+                               DeviceResiduals.at(0).bytes(), cudaMemcpyDeviceToHost, put_stream));
+    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, put_stream));
+}
+
+Tensor& LLamaRunState::get_res_ffn(int layer_idx, cudaStream_t main_stream) {
+    if(!Options.OffloadResidual) {
+        return DeviceResiduals.at(layer_idx);
+    }
+
+    CUDA_CHECK(cudaStreamWaitEvent(main_stream, OffloadResidualEvent, 0));
+    return DeviceResiduals.at(0);
+}
+
+void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
+    if(!Options.OffloadResidual) {
+        return;
+    }
+    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, main_stream));
+}
+
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B, int T, std::shared_ptr<TensorAllocator> alloc) {
     // we are *not* handling this as a single giant allocation
     // by using independent allocations, we give sanitizers a better chance of catching errors,
@@ -232,7 +269,24 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     Tensor d_emb = alloc->allocate(config.DType, "d_emb", {B, T, C});
 
     auto layers = builder.allocate_forward_buffers(lnf);
-
+    std::vector<Tensor> device_residuals;
+    std::vector<Tensor> offloaded_residuals;
+    if(options.OffloadResidual) {
+        device_residuals.reserve(2);
+        offloaded_residuals.reserve(config.NumLayers);
+        for(int i = 0; i < 2; ++i) {
+            device_residuals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
+        }
+        for(int i = 0; i < config.NumLayers; ++i) {
+            offloaded_residuals.push_back(
+                alloc->allocate(config.DType, "ffn-res-off", EAllocationType::PINNED, {B, T, C}));
+        }
+    } else {
+        device_residuals.reserve(config.NumLayers);
+        for(int i = 0; i < config.NumLayers; ++i) {
+            device_residuals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
+        }
+    }
 
     long num_c_groups = div_ceil(C, (long)(16 / get_dtype_size(config.DType) * 32));
     Tensor enc_bw_scratch = alloc->allocate(ETensorDType::INT32, "enc_bw_scratch", {B, T, num_c_groups * 5});
@@ -296,17 +350,9 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
 
     Tensor mm_scales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
 
-    std::vector<Tensor> offloaded_residuals;
-    if(options.OffloadResidual) {
-        for(int i = 0; i < config.NumLayers; ++i) {
-            offloaded_residuals.push_back(
-                alloc->allocate(config.DType, "ffn-res-off", EAllocationType::PINNED, {B, T, C}));
-        }
-    }
-
     return LLamaRunState{inputs, targets, inputs_cpu, targets_cpu, losses,
                          encoded, freq_cis, output, lnf, lnf_rstd, std::move(layers),
-                         std::move(offloaded_residuals), std::move(grads),
+                         std::move(device_residuals), std::move(offloaded_residuals), std::move(grads),
                          d_lnf, d_emb, rms_scratch, bias_scratch, cudnn_ws, enc_bw_scratch, enc_bw_idx, env_bw_info,
                          wgt_tp_buffer, act_tp_buffer, grd_tp_buffer,
                          abs_maxes, mm_scales,

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -64,6 +64,7 @@ private:
     Tensor tAttBuffer;
     Tensor tLN1Buffer;
     Tensor tResAttBuffer;
+    Tensor tFFNResBuffer;
 };
 
 Tensor RunStateBuilder::generate_frequencies() {
@@ -91,7 +92,7 @@ LLamaRunState::LayerActivations RunStateBuilder::allocate_basic_fwd_tensors(Tens
 
     Tensor qkv = allocate_or_reuse(Options.RecomputeQKV, tQKVBuffer, Config.DType, "qkv", B, T, Config.qkv_channels());
     Tensor res_att = allocate_or_reuse(Options.RecomputeBlock, tResAttBuffer, Config.DType, "res_att", B, T, C);
-    Tensor res_ffn = allocate(Config.DType, "res_ffn", B, T, C);
+    Tensor res_ffn = allocate_or_reuse(Options.OffloadResidual, tFFNResBuffer, Config.DType, "res_ffn", B, T, C);
     Tensor lse = allocate(ETensorDType::FP32, "lse", B, T, Config.NumQueryHeads);
     Tensor att_v = allocate_or_reuse(Options.RecomputeAtt, tAttBuffer, Config.DType, "att_v", B, T, C);
     // not needed for backward, so can reuse an existing buffer
@@ -252,6 +253,7 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     cudaEvent_t forward_done_event = create_named_event("forward done");
     cudaEvent_t backward_done_event = create_named_event("backward done");
     cudaEvent_t norm_done_event = create_named_event("norm done");
+    cudaEvent_t offload_event = create_named_event("offload_res_ffn");
     cudaEvent_t lmhead_done = create_named_event("optimizer lmhead done");
     cudaEvent_t optimizer_done_event = create_named_event("optimizer done");
     cudaEvent_t transfer_done_event = create_named_event("transfer done");
@@ -294,15 +296,24 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
 
     Tensor mm_scales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
 
+    std::vector<Tensor> offloaded_residuals;
+    if(options.OffloadResidual) {
+        for(int i = 0; i < config.NumLayers; ++i) {
+            offloaded_residuals.push_back(
+                alloc->allocate(config.DType, "ffn-res-off", EAllocationType::PINNED, {B, T, C}));
+        }
+    }
+
     return LLamaRunState{inputs, targets, inputs_cpu, targets_cpu, losses,
                          encoded, freq_cis, output, lnf, lnf_rstd, std::move(layers),
-                         std::move(grads),
+                         std::move(offloaded_residuals), std::move(grads),
                          d_lnf, d_emb, rms_scratch, bias_scratch, cudnn_ws, enc_bw_scratch, enc_bw_idx, env_bw_info,
-            wgt_tp_buffer, act_tp_buffer, grd_tp_buffer,
+                         wgt_tp_buffer, act_tp_buffer, grd_tp_buffer,
                          abs_maxes, mm_scales,
                          norm_buffer, host_buffer.get<float>(), host_buffer.get<float>() + 1,
                          options, std::move(alloc), deviceProp, main_stream, side_stream, side_stream_event,
-                         forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done, std::move(optimizer_events), optimizer_done_event,
+                         forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done, offload_event,
+                         std::move(optimizer_events), optimizer_done_event,
                          nullptr, nullptr, nullptr, cudnn_handle, cublas_handle};
 }
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -196,10 +196,15 @@ void LLamaRunState::fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream) {
         return;
     }
 
-    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, OffloadResidualEvent, 0));
-    CUDA_CHECK(cudaMemcpyAsync(DeviceResiduals.at(0).Data, OffloadedResiduals.at(layer_idx).Data,
-                               DeviceResiduals.at(0).bytes(), cudaMemcpyHostToDevice, fetch_stream));
-    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, fetch_stream));
+    int l2 = layer_idx % 2;
+    auto& status = OffloadedResidualState.at(l2);
+
+    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, status.Event, 0));
+    status.Layer = layer_idx;
+    status.Ready = false;
+    CUDA_CHECK(cudaMemcpyAsync(DeviceResiduals.at(l2).Data, OffloadedResiduals.at(layer_idx).Data,
+                               DeviceResiduals.at(l2).bytes(), cudaMemcpyHostToDevice, fetch_stream));
+    CUDA_CHECK(cudaEventRecord(status.Event, fetch_stream));
 }
 
 void LLamaRunState::put_res_ffn(int layer_idx, cudaStream_t put_stream) {
@@ -207,10 +212,13 @@ void LLamaRunState::put_res_ffn(int layer_idx, cudaStream_t put_stream) {
         return;
     }
 
-    CUDA_CHECK(cudaStreamWaitEvent(put_stream, OffloadResidualEvent, 0));
-    CUDA_CHECK(cudaMemcpyAsync(OffloadedResiduals.at(layer_idx).Data, DeviceResiduals.at(0).Data,
-                               DeviceResiduals.at(0).bytes(), cudaMemcpyDeviceToHost, put_stream));
-    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, put_stream));
+    int l2 = layer_idx % 2;
+    auto& status = OffloadedResidualState.at(l2);
+    status.Ready = false;
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, status.Event, 0));
+    CUDA_CHECK(cudaMemcpyAsync(OffloadedResiduals.at(layer_idx).Data, DeviceResiduals.at(l2).Data,
+                               DeviceResiduals.at(l2).bytes(), cudaMemcpyDeviceToHost, put_stream));
+    CUDA_CHECK(cudaEventRecord(status.Event, put_stream));
 }
 
 Tensor& LLamaRunState::get_res_ffn(int layer_idx, cudaStream_t main_stream) {
@@ -218,15 +226,22 @@ Tensor& LLamaRunState::get_res_ffn(int layer_idx, cudaStream_t main_stream) {
         return DeviceResiduals.at(layer_idx);
     }
 
-    CUDA_CHECK(cudaStreamWaitEvent(main_stream, OffloadResidualEvent, 0));
-    return DeviceResiduals.at(0);
+    int l2 = layer_idx % 2;
+    auto& status = OffloadedResidualState.at(l2);
+    if(!status.Ready) {
+        CUDA_CHECK(cudaStreamWaitEvent(main_stream, status.Event, 0));
+        status.Ready = true;
+    }
+    return DeviceResiduals.at(l2);
 }
 
 void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
     if(!Options.OffloadResidual) {
         return;
     }
-    CUDA_CHECK(cudaEventRecord(OffloadResidualEvent, main_stream));
+    int l2 = layer_idx % 2;
+    auto& status = OffloadedResidualState.at(l2);
+    CUDA_CHECK(cudaEventRecord(status.Event, main_stream));
 }
 
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B, int T, std::shared_ptr<TensorAllocator> alloc) {
@@ -271,11 +286,16 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     auto layers = builder.allocate_forward_buffers(lnf);
     std::vector<Tensor> device_residuals;
     std::vector<Tensor> offloaded_residuals;
+    std::vector<LLamaRunState::sOffloadedResidualState> offloaded_residual_states;
     if(options.OffloadResidual) {
         device_residuals.reserve(2);
         offloaded_residuals.reserve(config.NumLayers);
         for(int i = 0; i < 2; ++i) {
             device_residuals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
+            offloaded_residual_states.emplace_back(
+                create_named_event((std::string("offload_res_ffn_") + std::to_string(i)).c_str()),
+                -1, false
+                );
         }
         for(int i = 0; i < config.NumLayers; ++i) {
             offloaded_residuals.push_back(
@@ -307,7 +327,6 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     cudaEvent_t forward_done_event = create_named_event("forward done");
     cudaEvent_t backward_done_event = create_named_event("backward done");
     cudaEvent_t norm_done_event = create_named_event("norm done");
-    cudaEvent_t offload_event = create_named_event("offload_res_ffn");
     cudaEvent_t lmhead_done = create_named_event("optimizer lmhead done");
     cudaEvent_t optimizer_done_event = create_named_event("optimizer done");
     cudaEvent_t transfer_done_event = create_named_event("transfer done");
@@ -352,13 +371,14 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
 
     return LLamaRunState{inputs, targets, inputs_cpu, targets_cpu, losses,
                          encoded, freq_cis, output, lnf, lnf_rstd, std::move(layers),
-                         std::move(device_residuals), std::move(offloaded_residuals), std::move(grads),
+                         std::move(device_residuals), std::move(offloaded_residuals), std::move(offloaded_residual_states),
+                         std::move(grads),
                          d_lnf, d_emb, rms_scratch, bias_scratch, cudnn_ws, enc_bw_scratch, enc_bw_idx, env_bw_info,
                          wgt_tp_buffer, act_tp_buffer, grd_tp_buffer,
                          abs_maxes, mm_scales,
                          norm_buffer, host_buffer.get<float>(), host_buffer.get<float>() + 1,
                          options, std::move(alloc), deviceProp, main_stream, side_stream, side_stream_event,
-                         forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done, offload_event,
+                         forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done,
                          std::move(optimizer_events), optimizer_done_event,
                          nullptr, nullptr, nullptr, cudnn_handle, cublas_handle};
 }

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -207,6 +207,15 @@ void LLamaRunState::fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream) {
     CUDA_CHECK(cudaEventRecord(status.Event, fetch_stream));
 }
 
+void LLamaRunState::mark_res_ffn_ready(int layer_idx, cudaStream_t main_stream) {
+    if(!Options.OffloadResidual) {
+        return;
+    }
+    auto& status = OffloadedResidualState.at(layer_idx % 2);
+    status.Layer = layer_idx;
+    CUDA_CHECK(cudaEventRecord(ResidualsAreReady, main_stream));
+}
+
 void LLamaRunState::put_res_ffn(int layer_idx, cudaStream_t put_stream) {
     if(!Options.OffloadResidual) {
         return;
@@ -215,7 +224,11 @@ void LLamaRunState::put_res_ffn(int layer_idx, cudaStream_t put_stream) {
     int l2 = layer_idx % 2;
     auto& status = OffloadedResidualState.at(l2);
     status.Ready = false;
-    CUDA_CHECK(cudaStreamWaitEvent(put_stream, status.Event, 0));
+    if(status.Layer != layer_idx) {
+        throw std::logic_error("Mismatched layer index in put_res_ffn");
+    }
+
+    CUDA_CHECK(cudaStreamWaitEvent(put_stream, ResidualsAreReady, 0));
     CUDA_CHECK(cudaMemcpyAsync(OffloadedResiduals.at(layer_idx).Data, DeviceResiduals.at(l2).Data,
                                DeviceResiduals.at(l2).bytes(), cudaMemcpyDeviceToHost, put_stream));
     CUDA_CHECK(cudaEventRecord(status.Event, put_stream));
@@ -287,6 +300,7 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     std::vector<Tensor> device_residuals;
     std::vector<Tensor> offloaded_residuals;
     std::vector<LLamaRunState::sOffloadedResidualState> offloaded_residual_states;
+    cudaEvent_t residual_ready_event = create_named_event("residual_ready");
     if(options.OffloadResidual) {
         device_residuals.reserve(2);
         offloaded_residuals.reserve(config.NumLayers);
@@ -379,7 +393,7 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
                          norm_buffer, host_buffer.get<float>(), host_buffer.get<float>() + 1,
                          options, std::move(alloc), deviceProp, main_stream, side_stream, side_stream_event,
                          forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done,
-                         std::move(optimizer_events), optimizer_done_event,
+                         std::move(optimizer_events), optimizer_done_event, residual_ready_event,
                          nullptr, nullptr, nullptr, cudnn_handle, cublas_handle};
 }
 

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -38,7 +38,6 @@ struct LLamaRunState {
         Tensor MlpUp;       // (B, T, 2*Ch)
         Tensor MlpDown;     // (B, T, C)
         QTensor SwiGLu;     // (B, T, Ch)
-        Tensor ResidualFFN; // (B, T, C)
     };
 
     struct LayerGradients {
@@ -66,7 +65,14 @@ struct LLamaRunState {
     Tensor LNF;             // (B, T, C)
     Tensor LNF_Rstd;        // (B, T)
     std::vector<LayerActivations> Acts;
+
+    std::vector<Tensor> DeviceResiduals;        // (B, T, C)
     std::vector<Tensor> OffloadedResiduals;
+
+    void fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream);
+    void put_res_ffn(int layer_idx, cudaStream_t put_stream);
+    Tensor& get_res_ffn(int layer_idx, cudaStream_t main_stream);
+    void release_res_ffn(int layer_idx, cudaStream_t main_stream);
 
     // Gradients
     std::vector<LayerGradients> DActs;

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -66,6 +66,7 @@ struct LLamaRunState {
     Tensor LNF;             // (B, T, C)
     Tensor LNF_Rstd;        // (B, T)
     std::vector<LayerActivations> Acts;
+    std::vector<Tensor> OffloadedResiduals;
 
     // Gradients
     std::vector<LayerGradients> DActs;
@@ -107,6 +108,7 @@ struct LLamaRunState {
     cudaEvent_t TransferDone;       //!< recorded once CPU-side buffers have been copied to GPU
     cudaEvent_t NormDone;           //!< recorded after norm calculation completes
     cudaEvent_t OptEmbeddingsDone;      //!< recorded after the optimizer has done an update to the LMHead
+    cudaEvent_t OffloadResidualEvent;
     std::vector<cudaEvent_t> LayerUpdateDone;   //!< Recorded after the optimizer has done an update to the specified layer.
     cudaEvent_t OptimizerDone;      //!< recorded after the optimizer completes
 

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -80,6 +80,7 @@ struct LLamaRunState {
     void fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream);
     void put_res_ffn(int layer_idx, cudaStream_t put_stream);
     Tensor& get_res_ffn(int layer_idx, cudaStream_t main_stream);
+    void mark_res_ffn_ready(int layer_idx, cudaStream_t main_stream);
     void release_res_ffn(int layer_idx, cudaStream_t main_stream);
 
     // Gradients
@@ -124,6 +125,7 @@ struct LLamaRunState {
     cudaEvent_t OptEmbeddingsDone;      //!< recorded after the optimizer has done an update to the LMHead
     std::vector<cudaEvent_t> LayerUpdateDone;   //!< Recorded after the optimizer has done an update to the specified layer.
     cudaEvent_t OptimizerDone;      //!< recorded after the optimizer completes
+    cudaEvent_t ResidualsAreReady;  //!< recorded after the residuals have been calculated in forward, indicating that they may be offloaded
 
     cudaGraphExec_t GlobalNormGraph;
     cudaGraphExec_t ForwardBlockGraph;

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -69,6 +69,14 @@ struct LLamaRunState {
     std::vector<Tensor> DeviceResiduals;        // (B, T, C)
     std::vector<Tensor> OffloadedResiduals;
 
+    struct sOffloadedResidualState {
+        cudaEvent_t Event;
+        int Layer;
+        int Ready;
+    };
+
+    std::vector<sOffloadedResidualState> OffloadedResidualState;
+
     void fetch_res_ffn(int layer_idx, cudaStream_t fetch_stream);
     void put_res_ffn(int layer_idx, cudaStream_t put_stream);
     Tensor& get_res_ffn(int layer_idx, cudaStream_t main_stream);
@@ -114,7 +122,6 @@ struct LLamaRunState {
     cudaEvent_t TransferDone;       //!< recorded once CPU-side buffers have been copied to GPU
     cudaEvent_t NormDone;           //!< recorded after norm calculation completes
     cudaEvent_t OptEmbeddingsDone;      //!< recorded after the optimizer has done an update to the LMHead
-    cudaEvent_t OffloadResidualEvent;
     std::vector<cudaEvent_t> LayerUpdateDone;   //!< Recorded after the optimizer has done an update to the specified layer.
     cudaEvent_t OptimizerDone;      //!< recorded after the optimizer completes
 

--- a/train.cpp
+++ b/train.cpp
@@ -137,6 +137,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_flag("--recompute-qkv", Options.RecomputeQKV, "Recompute the qkv projections during the backward pass");
     app.add_flag("--recompute-att", Options.RecomputeAtt, "Recompute the attention block during the backward pass");
     app.add_flag("--recompute-block", Options.RecomputeBlock, "Recompute the entire transformer block");
+    app.add_flag("--offload-residual", Options.OffloadResidual, "Offload the residual of the feed-forward block to host memory");
     app.add_flag("--use-cuda-graphs,!--no-use-cuda-graphs", Options.UseCudaGraphs, "Enable/disable use of cuda graphs");
     auto zero = app.add_option("--zero-level", ZeroLevel, "Zero redundancy level: 1 - sharded optimizer; 2 - sharded gradients; 3 - sharded weights");
     app.add_flag("--offload-master", Options.OffloadMaster, "Store master weights in pinned host memory.");


### PR DESCRIPTION
Allows offloading the FFN residual (the only activation that cannot be recomputed) to host memory, using a double-buffer implementation.
In this way, we decouple the activation memory cost from the network depth; together with the recent lmhead-chunking, this allows us to run batch-size=16 for 14B on 4x4090, which is finally enough to (mostly) hide the communication latency, getting us from 7.3k tok/s to 7.8k tok/s in fp8, and to 5.1k in bf16. Especially in bf16, that is actually really good, as it corresponds to about 66% speed-of-light; due to recomputation, we can't expect more than 70-75% even in perfect circumstances.