### PR TITLE
L40 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,32 +395,37 @@ All settings use `--lmhead-chunks=${BATCH_SIZE}`
 ^10: `--offload-opt-m --recompute-swiglu --recompute-norm`
 
 ### L40S
+On the L40S system, we found zero-copy access to offloaded optimizer states (`--use-zero-copy`) to be much more performant than cudaMemcpy-based double buffering.
 
 | Model        | nGPU | DType | Batch | TPS  | SOL | TTB   |
 |--------------|------|-------|-------|------|-----|-------|
-| Qwen2.5-0.5B | 1    | fp8   | 32    | 48k  | 53% | 5.47h |
-| Qwen2.5-0.5B | 1    | bf16  | 16    | 42k  | 72% | 6:36h |
+| Qwen2.5-0.5B | 1    | fp8   | 32    | 47k  | 52% | 5:55h |
+| Qwen2.5-0.5B | 1    | bf16  | 16    | 44k  | 74% | 6:20h |
 | Qwen2.5-1.5B | 1    | fp8   | 8     | 20k  | 63% | 14h   |
 | Qwen2.5-1.5B | 1    | bf16  | 8     | 17k  | 87% | 16h   |
 | Qwen2.5-3B   | 1    | fp8   | 4     | 11k  | 66% | 25h   |
 | Qwen2.5-3B   | 1    | bf16  | 4     | 8.9k | 93% | 31h   |
-| Qwen2.5-7B¹  | 1    | fp8   | 4     | 5.1k | 65% | 71h   |
-| Qwen2.5-7B²  | 1    | bf16  | 4     | 3.9k | 93% | 45h   |
-| Qwen2.5-0.5B | 4    | fp8   | 32    | 189k | 52% | 1.28h |
-| Qwen2.5-0.5B | 4    | bf16  | 16    | 170k | 72% | 1:38h |
-| Qwen2.5-1.5B | 4    | fp8   | 16    | 81k  | 62% | 3.25h |
+| Qwen2.5-7B¹  | 1    | fp8   | 4     | 5.2k | 66% | 54h   |
+| Qwen2.5-7B²  | 1    | bf16  | 4     | 3.9k | 94% | 70h   |
+| Qwen2.5-14B³ | 1    | fp8   | 16    | 1.7k | 44% | 159h  |
+| Qwen2.5-14B⁴ | 1    | bf16  | 16    | 1.5k | 70% | 185h  |
+| Qwen2.5-0.5B | 4    | fp8   | 32    | 185k | 50% | 1:30h |
+| Qwen2.5-0.5B | 4    | bf16  | 16    | 169k | 71% | 1:38h |
+| Qwen2.5-1.5B | 4    | fp8   | 16    | 79k  | 60% | 3:30h |
 | Qwen2.5-1.5B | 4    | bf16  | 8     | 65k  | 85% | 4:16h |
-| Qwen2.5-3B   | 4    | fp8   | 8     | 45k  | 65% | 6:10h |
+| Qwen2.5-3B   | 4    | fp8   | 8     | 44k  | 63% | 6:20h |
 | Qwen2.5-3B   | 4    | bf16  | 8     | 35k  | 90% | 7:56h |
-| Qwen2.5-7B¹  | 4    | fp8   | 4     | 18k  | 59% | 15h   |
-| Qwen2.5-7B²  | 4    | bf16  | 4     | 15k  | 88% | 18h   |
-| Qwen2.5-14B³ | 4    | fp8   | 4     | 7.1k | 45% | 39h   |
-| Qwen2.5-14B³ | 4    | bf16  | 4     | 4.8k | 57% | 58h   |
+| Qwen2.5-7B¹  | 4    | fp8   | 4     | 18k  | 58% | 16h   |
+| Qwen2.5-7B²  | 4    | bf16  | 4     | 15k  | 87% | 18h   |
+| Qwen2.5-14B⁵ | 4    | fp8   | 64    | 8.7k | 54% | 32h   |
+| Qwen2.5-14B⁶ | 4    | bf16  | 64    | 6.3k | 73% | 44h   |
 
-^1: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm --offload-master`  
-^2: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm`  
-^3: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --offload-master --shard-weights --persistent-quants --offload-quants`  
-^4: `--offload-opt-m --offload-opt-v --recompute-ffn --recompute-norm --offload-master --shard-weights`  
+^1: `--offload-opt-m --offload-opt-v --offload-master`  
+^2: `--offload-opt-m --offload-opt-v --recompute-swiglu --recompute-norm`
+^3: `--offload-opt-m --offload-opt-v --offload-master --recompute-block --use-zero-copy --lmhead-chunks=16 --shard-weights --offload-residual --persistent-quants --offload-quants`
+^4: `--offload-opt-m --offload-opt-v --offload-master --recompute-block --use-zero-copy --lmhead-chunks=16 --shard-weights --offload-residual`
+^5: `--offload-opt-m --offload-opt-v --offload-master --recompute-block --use-zero-copy --lmhead-chunks=16 --shard-weights --offload-residual --shard-gradients --persistent-quants --offload-quants`  
+^6: `--offload-opt-m --offload-opt-v --offload-master --recompute-block --use-zero-copy --lmhead-chunks=16 --shard-weights --offload-residual --shard-gradients`  
 
 ### RTX 5090 Performance Benchmarks
 

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -178,7 +178,7 @@ NB_MODULE(_pyllmq, m) {
         .def("__init__", [](LLamaOptions *t, bool recompute_swiglu, bool recompute_rmsnorm,
             bool recompute_ffn, bool recompute_qkv, bool recompute_att, bool recompute_block, bool offload_residual,
             bool use_cuda_graphs,
-            bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v,
+            bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v, bool use_zero_copy,
             bool use_write_combined, bool shard_weights, bool persistent_quants, bool shard_gradients, bool use_all_to_all_reduce,
             bool init_projections_to_zero, int lmhead_chunks,
             const std::string matmul_type, const std::string master_dtype, const std::string momentum_type, const std::string variance_type) {
@@ -196,6 +196,7 @@ NB_MODULE(_pyllmq, m) {
                 .OffloadQuants = offload_quants,
                 .OffloadOptM = offload_opt_m,
                 .OffloadOptV = offload_opt_v,
+                .UseZeroCopy = use_zero_copy,
                 .UseWriteCombined = use_write_combined,
                 .ShardWeights = shard_weights,
                 .PersistentQuants = persistent_quants,
@@ -214,7 +215,8 @@ NB_MODULE(_pyllmq, m) {
              nb::arg("offload_residual") = false,
              nb::arg("use_cuda_graphs") = true,   nb::arg("offload_master") = false,
              nb::arg("offload_quants") = false,   nb::arg("offload_opt_m") = false,
-             nb::arg("offload_opt_v") = false,    nb::arg("use_write_combined") = false,
+             nb::arg("offload_opt_v") = false,    nb::arg("use_zero_copy") = false,
+             nb::arg("use_write_combined") = false,
              nb::arg("shard_weights") = false,    nb::arg("persistent_quants") = false,
              nb::arg("shard_gradients") = false,  nb::arg("use_all_to_all_reduce") = false,
              nb::arg("init_projections_to_zero") = false, nb::arg("lmhead_chunks") = 1,
@@ -234,6 +236,7 @@ NB_MODULE(_pyllmq, m) {
         .def_rw("offload_quants", &LLamaOptions::OffloadQuants)
         .def_rw("offload_opt_m", &LLamaOptions::OffloadOptM)
         .def_rw("offload_opt_v", &LLamaOptions::OffloadOptV)
+        .def_rw("use_zero_copy", &LLamaOptions::UseZeroCopy)
         .def_rw("use_write_combined", &LLamaOptions::UseWriteCombined)
         .def_rw("shard_weights", &LLamaOptions::ShardWeights)
         .def_rw("persistent_quants", &LLamaOptions::PersistentQuants)

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -33,6 +33,7 @@ struct LLamaOptions {
     bool OffloadQuants = false;
     bool OffloadOptM   = false;
     bool OffloadOptV   = false;
+    bool UseZeroCopy = true;
     bool UseWriteCombined = false;
     bool ShardWeights = false;
     bool PersistentQuants = false;

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -9,7 +9,7 @@
 #include "utilities/comm.h"
 
 void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_stream) {
-    if(!mOffloadM && !mOffloadV) return;
+    if((!mOffloadM && !mOffloadV) || mUseZeroCopy) return;
 
     int buffer = layer_idx % 2;
     auto& stat = mStatus.at(buffer);
@@ -62,12 +62,12 @@ void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_s
 }
 
 sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_m(int layer_idx, cudaStream_t stream) {
-    if(!mOffloadM) return mOptM.Blocks[layer_idx];
+    if(!mOffloadM || mUseZeroCopy) return mOptM.Blocks[layer_idx];
     return get_block_from(layer_idx, stream, mOptMBuffer.at(layer_idx % 2));
 }
 
 sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_v(int layer_idx, cudaStream_t stream) {
-    if(!mOffloadV) return mOptV.Blocks[layer_idx];
+    if(!mOffloadV || mUseZeroCopy) return mOptV.Blocks[layer_idx];
     return get_block_from(layer_idx, stream, mOptVBuffer.at(layer_idx % 2));
 }
 
@@ -90,6 +90,8 @@ sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_from(int 
 }
 
 void LLamaOptimizerStateManager::store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream)  {
+    if (mUseZeroCopy) return;
+
     int buffer = layer_idx % 2;
     if(mOffloadM) {
         store_one_block(layer_idx, stream, put_stream, mOptMBuffer[buffer], mOptM.Blocks[layer_idx]);
@@ -110,8 +112,6 @@ void LLamaOptimizerStateManager::store_block(int layer_idx, cudaStream_t stream,
 }
 
 void LLamaOptimizerStateManager::store_one_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& dst) {
-
-
     auto& stat = mStatus.at(layer_idx % 2);
 
     auto send = [put_stream](TensorShard& dst, TensorShard& src) {
@@ -164,7 +164,7 @@ void zero_opt_state(sLLamaWeights& weights, cudaStream_t stream) {
 }
 
 LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc):
-    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV)
+    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV), mUseZeroCopy(options.UseZeroCopy)
 {
     {
         auto ctx = alloc.with_context("Adam M");
@@ -174,7 +174,7 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOpt
         mOptM = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
         zero_opt_state(mOptM, stream);
 
-        if(options.OffloadOptM){
+        if(options.OffloadOptM && !mUseZeroCopy) {
             mOptMBuffer[0] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
                                                   EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
             mOptMBuffer[1] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
@@ -189,7 +189,7 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOpt
         c.DType = options.OptVarianceType;
         mOptV = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
         zero_opt_state(mOptV, stream);
-        if(options.OffloadOptV){
+        if(options.OffloadOptV && !mUseZeroCopy){
             mOptVBuffer[0] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
                                                   EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
             mOptVBuffer[1] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
@@ -197,7 +197,7 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOpt
         }
     }
 
-    if(options.OffloadOptM || options.OffloadOptV) {
+    if((options.OffloadOptM || options.OffloadOptV) && !mUseZeroCopy) {
         mStatus[0] = sBufferStatus{-1, create_named_event("opt_fetch_0"), false, true};
         mStatus[1] = sBufferStatus{-1, create_named_event("opt_fetch_1"), false, true};
     }

--- a/src/models/llama_optimizer.h
+++ b/src/models/llama_optimizer.h
@@ -39,6 +39,7 @@ private:
 
     bool mOffloadM;
     bool mOffloadV;
+    bool mUseZeroCopy;
 
     sLLamaBlockWeights<TensorShard>& get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf);
     void store_one_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& dst);

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -174,6 +174,7 @@ LLamaWeightsManager::LLamaWeightsManager(const LLamaConfig& config, const LLamaO
     mHeadID = config.TiedWordEmbeddings ? 0 : 1;
 
     mOffloadMaster = options.OffloadMaster;
+    mUseZeroCopy = options.UseZeroCopy;
 }
 
 LLamaWeightsManager::~LLamaWeightsManager() {
@@ -214,7 +215,7 @@ std::pair<float*, float*> LLamaWeightsManager::get_scales_for_block(int layer_id
 
 
 void LLamaWeightsManager::setup_master_buffers(const LLamaConfig& config, TensorAllocator& alloc) {
-    if (mOffloadMaster) {
+    if (mOffloadMaster && !mUseZeroCopy) {
         for(int i = 0; i < 2; ++i) {
             auto& buf = mMasterDeviceDoubleBuffer.at(i);
             if (mWorkMatDType != mMasterDType) {
@@ -266,7 +267,7 @@ TensorShard& LLamaWeightsManager::get_master_lnf_w() {
 }
 
 void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_stream) {
-    if(!mOffloadMaster) return;
+    if(!mOffloadMaster || mUseZeroCopy) return;
 
     int buffer = layer_idx % 2;
     auto& buf = mMasterDeviceDoubleBuffer.at(buffer);
@@ -303,7 +304,7 @@ void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_s
 }
 
 sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer_idx, cudaStream_t stream) {
-    if(!mOffloadMaster) return mMaster.Blocks[layer_idx];
+    if(!mOffloadMaster || mUseZeroCopy) return mMaster.Blocks[layer_idx];
 
     int buffer = layer_idx % 2;
     auto& buf = mMasterDeviceDoubleBuffer.at(buffer);
@@ -313,7 +314,7 @@ sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer
 }
 
 void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, LLamaRunState& run_state) {
-    if(!mOffloadMaster) return;
+    if(!mOffloadMaster || mUseZeroCopy) return;
 
     int buffer = layer_idx % 2;
     auto& buf = mMasterDeviceDoubleBuffer.at(buffer);

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -170,6 +170,7 @@ protected:
     ETensorDType mWorkMatDType;
 
     bool mOffloadMaster;
+    bool mUseZeroCopy;
 };
 
 class LLamaOptimizerParamManager {

--- a/train.cpp
+++ b/train.cpp
@@ -151,6 +151,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_flag("--offload-quants", Options.OffloadQuants, "Store quantized weights in pinned host memory.")->needs(persist);
     app.add_flag("--offload-opt-m", Options.OffloadOptM, "Store first-order momentum in pinned host memory.");
     app.add_flag("--offload-opt-v", Options.OffloadOptV, "Store second-order momentum in pinned host memory.");
+    app.add_flag("--use-zero-copy", Options.UseZeroCopy, "Use ZeroCopy memory access, instead of double-buffered cudaMemcpy, for offloaded optimizer states. On consumer cards, DMA appears to be much slower, whereas on professional cards it is faster.");
     app.add_flag("--shard-gradients", Options.ShardGradients, "Shard gradients across GPUs")->excludes(zero);
     app.add_flag("--memcpy-all-gather", MemcpyAllGather, "Use memcpy to perform all-gathers. Currently only supported by the threads backend.");
     app.add_flag("--memcpy-send-recv", MemcpySendRecv, "Use memcpy to perform send/receive (all-to-all). Currently only supported by the threads backend.");
@@ -277,6 +278,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
         {"offload-quants",     Options.OffloadQuants},
         {"offload-opt-m",      Options.OffloadOptM},
         {"offload-opt-v",      Options.OffloadOptV},
+        {"use-zero-copy",      Options.UseZeroCopy},
         {"shard-weights",      Options.ShardWeights},
         {"shard-gradients",    Options.ShardGradients},
         {"persistent-quants",  Options.PersistentQuants},


### PR DESCRIPTION
Re-add the option to use zero-copy direct memory access to transfer offloaded optimizer states. For some GPUs (datacenter/professional), this seems to be more performant.
Concretely, I have observed about 4x speedup of the optimizer on L40s. It makes sense that zero-copy would be better on professional cards than on gaming cards, but at this point, I  have no idea why cudaMemcpy is actively harmful.