### PR TITLE
Chunked attn bwd

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -127,6 +127,9 @@ jobs:
             args: "--recompute-swiglu --recompute-norm"
           - name: "Offload Opt"
             args: "--offload-opt-m --offload-opt-v --offload-master"
+          # While not strictly a recomputation, chunked attention should be bitwise identical, too
+          - name: "Chunked attention"
+            args: "--recompute-att --attn-bwd-chunks 4"
         dtype:
           - name: "BF16"
             args: "--matmul-dtype=bf16"

--- a/scripts/modal_test_app.py
+++ b/scripts/modal_test_app.py
@@ -76,7 +76,7 @@ def compare_and_create_report(result, expected):
 )
 def run_recompute_test(test_args: list[str]):
     """Run recomputation tests on Modal."""
-    from pyllmq.tests.run import parse_args, run_training, compare_results
+    from pyllmq.tests.run import parse_args, run_training
     from pyllmq.tests.recompute import disable_recompute
 
     # Parse test arguments into config

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -25,6 +25,7 @@ def setup_options(config: pyllmq.TrainingConfig) -> pyllmq.LLamaOptions:
     options.recompute_att = config.recompute_att or config.recompute_block
 
     options.lmhead_chunks = config.lmhead_chunks
+    options.attn_bwd_chunks = config.attn_bwd_chunks
 
     # Optimizer dtype
     options.momentum_type = config.opt_m_dtype
@@ -97,6 +98,7 @@ def parse_args():
     parser.add_argument("--seq-len", "--seq-length", type=int, default=default.seq_len, help="Sequence length")
     parser.add_argument("--grad-accumulation", type=int, default=default.grad_accumulation, help="Gradient accumulation steps")
     parser.add_argument("--lmhead-chunks", type=int, default=default.lmhead_chunks, help="Run LM-head in smaller chunks")
+    parser.add_argument("--attn-bwd-chunks", type=int, default=default.attn_bwd_chunks, help="Run attention backward in smaller chunks")
 
     # Optimizer
     parser.add_argument("--learning-rate", "--lr", type=float, default=default.learning_rate, help="Learning rate")

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -180,7 +180,7 @@ NB_MODULE(_pyllmq, m) {
             bool use_cuda_graphs,
             bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v, bool use_zero_copy,
             bool use_write_combined, bool shard_weights, bool persistent_quants, bool shard_gradients, bool use_all_to_all_reduce,
-            bool init_projections_to_zero, int lmhead_chunks,
+            bool init_projections_to_zero, int lmhead_chunks, int attn_bwd_chunks,
             const std::string matmul_type, const std::string gradient_type, const std::string master_dtype, const std::string momentum_type, const std::string variance_type) {
             new (t) LLamaOptions{
                 .RecomputeSwiGLu = recompute_swiglu,
@@ -191,6 +191,7 @@ NB_MODULE(_pyllmq, m) {
                 .RecomputeBlock = recompute_block,
                 .OffloadResidual = offload_residual,
                 .LMHeadChunks = lmhead_chunks,
+                .AttBwdChunks = attn_bwd_chunks,
                 .UseCudaGraphs = use_cuda_graphs,
                 .OffloadMaster = offload_master,
                 .OffloadQuants = offload_quants,
@@ -221,6 +222,7 @@ NB_MODULE(_pyllmq, m) {
              nb::arg("shard_weights") = false,    nb::arg("persistent_quants") = false,
              nb::arg("shard_gradients") = false,  nb::arg("use_all_to_all_reduce") = false,
              nb::arg("init_projections_to_zero") = false, nb::arg("lmhead_chunks") = 1,
+             nb::arg("attn_bwd_chunks") = 1,
              nb::arg("matmul_type") = "",         nb::arg("gradient_type") = "",
              nb::arg("master_dtype") = "",
              nb::arg("momentum_type") = "fp32",   nb::arg("variance_type") = "fp32"
@@ -233,6 +235,7 @@ NB_MODULE(_pyllmq, m) {
         .def_rw("recompute_block", &LLamaOptions::RecomputeBlock)
         .def_rw("offload_residual", &LLamaOptions::OffloadResidual)
         .def_rw("lmhead_chunks", &LLamaOptions::LMHeadChunks)
+        .def_rw("attn_bwd_chunks", &LLamaOptions::AttBwdChunks)
         .def_rw("use_cuda_graphs", &LLamaOptions::UseCudaGraphs)
         .def_rw("offload_master", &LLamaOptions::OffloadMaster)
         .def_rw("offload_quants", &LLamaOptions::OffloadQuants)

--- a/src/binding/python/tests/recompute.py
+++ b/src/binding/python/tests/recompute.py
@@ -32,6 +32,7 @@ def disable_recompute(config: RunConfig):
     baseline_config.offload_master = False
     baseline_config.offload_opt_v = False
     baseline_config.offload_opt_m = False
+    baseline_config.attn_bwd_chunks = 1
     return baseline_config
 
 

--- a/src/binding/python/tests/run.py
+++ b/src/binding/python/tests/run.py
@@ -14,6 +14,7 @@ class RunConfig:
     seq_len: int = 1024
     grad_accum: int = 4
     lmhead_chunks: int = 1
+    attn_bwd_chunks: int = 1
     max_steps: int = 10
 
     # Optimizer settings
@@ -118,6 +119,7 @@ def _create_options(config: RunConfig) -> pyllmq.LLamaOptions:
     options.momentum_type = config.opt_m_dtype
     options.variance_type = config.opt_v_dtype
     options.lmhead_chunks = config.lmhead_chunks
+    options.attn_bwd_chunks = config.attn_bwd_chunks
     options.offload_residual = config.offload_residual
 
     options.offload_opt_m = config.offload_opt_m
@@ -219,6 +221,8 @@ def parse_args(args: list = None) -> RunConfig:
                         help="Number of micro-batches per optimizer step")
     parser.add_argument("--lmhead-chunks", type=int, default=RunConfig.lmhead_chunks,
                         help="Number of chunks for the lm-head")
+    parser.add_argument("--attn-bwd-chunks", type=int, default=RunConfig.attn_bwd_chunks,
+                        help="Number of chunks for attention backward")
 
     # Recomputation options
     parser.add_argument("--recompute-swiglu", action="store_true",

--- a/src/binding/python/training.py
+++ b/src/binding/python/training.py
@@ -25,6 +25,7 @@ class TrainingConfig:
     seq_len: int = 1024
     grad_accumulation: int = 4
     lmhead_chunks: int = 1
+    attn_bwd_chunks: int = 1
 
     # Optimizer configuration
     learning_rate: float = 1e-5

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -598,7 +598,16 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
                  accumulate, *rs, B, T, C, C, false, main_stream);
 
-    attention_backward_cudnn(d_acts.DQKV.Value, acts.LSE, acts.Att.Value, d_acts.DAttY, acts.QKV, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
+    for (int i=0; i < Options.AttBwdChunks; ++i) {
+        long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
+        Tensor d_qkv = shard_view(d_acts.DQKV.Value, i, Options.AttBwdChunks);
+        Tensor lse = shard_view(acts.LSE, i, Options.AttBwdChunks);
+        Tensor att = shard_view(acts.Att.Value, i, Options.AttBwdChunks);
+        Tensor d_atty = shard_view(d_acts.DAttY, i, Options.AttBwdChunks);
+        Tensor qkv = shard_view(acts.QKV, i, Options.AttBwdChunks);
+        attention_backward_cudnn(d_qkv, lse, att, d_atty, qkv, rs->Workspace, rs->CudnnHandle,
+            chunk_batch_size, T, Hq, Hkv, Hs, main_stream);
+    }
     rope_backward(d_acts.DQKV.Value, d_acts.DQKV.Value, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
 
     if (d_acts.DQKV.Quant.has_value()) {

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -27,6 +27,7 @@ struct LLamaOptions {
     bool RecomputeBlock = false;
     bool OffloadResidual = false;
     int LMHeadChunks = 1;
+    int AttBwdChunks = 1;
     bool UseCudaGraphs = false;
 
     bool OffloadMaster = false;

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -254,7 +254,7 @@ void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
     CUDA_CHECK(cudaEventRecord(status.Event, main_stream));
 }
 
-LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B, int T, std::shared_ptr<TensorAllocator> alloc) {
+LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
     // we are *not* handling this as a single giant allocation
     // by using independent allocations, we give sanitizers a better chance of catching errors,
     // and we never have to worry about tensor alignment
@@ -277,7 +277,7 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     Tensor encoded = alloc->allocate(config.DType, "encoded", {B, T, C});
     Tensor freq_cis = builder.generate_frequencies();
     // We're chunking the logit computation, so we can allocate a much smaller tensor.
-    int out_size = div_exact(B*T, options.LMHeadChunks);
+    long out_size = div_exact(B*T, (long)options.LMHeadChunks);
     Tensor output = alloc->allocate(config.DType, "output", {out_size, V});
     Tensor lnf = alloc->allocate(config.DType, "lnf", {B, T, C});
     Tensor lnf_rstd = alloc->allocate(ETensorDType::FP32, "lnf_rstd", {B, T});
@@ -285,7 +285,10 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B
     long rms_scratch_size = get_rmsnorm_backward_scratch_size(C, deviceProp);
     long bias_scratch_size = get_bias_backward_scratch_size(config.DType, config.qkv_channels(), deviceProp);
     cudnnHandle_t cudnn_handle = create_cudnn_handle();
-    long ws_size = cudnn_get_workspace_size(B, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), cudnn_handle);
+
+    // batch size for chunked attention backward
+    long chunk_batch_size = div_exact(B, (long)options.AttBwdChunks);
+    long ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), cudnn_handle);
     ws_size = std::max(ws_size, 32l * 1024 * 1024); // Hardcoding workspace to 32MiB but only Hopper needs 32 (for others 4 is OK)
     cublasLtHandle_t cublas_handle = create_cublaslt_handle();
     Tensor rms_scratch = alloc->allocate(ETensorDType::BYTE, "rms_scratch", {rms_scratch_size});

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -140,7 +140,7 @@ struct LLamaRunState {
     cublasLtHandle_t CublasLtHandle;
 };
 
-LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, int B, int T, std::shared_ptr<TensorAllocator> alloc);
+LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);
 
 float get_loss(LLamaRunState& acts);
 float get_norm(LLamaRunState& acts);

--- a/train.cpp
+++ b/train.cpp
@@ -104,6 +104,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_option("--batch,--batch-size", B, "micro-batch size");
     app.add_option("--seq-len,--seq-length", T, "sequence length");
     app.add_option("--lmhead-chunks", Options.LMHeadChunks, "Run the LM-Head in chunks to avoid materializing the large logit tensor.");
+    app.add_option("--attn-bwd-chunks", Options.AttBwdChunks, "Run the attention backward pass in chunks, to avoid having to materialize a large workspace tensor.");
 
     // debug
     app.add_option("--debug-log-allocations", LogAllocations, "Log all memory allocations larger than the given number (in MiB)");
@@ -278,6 +279,8 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
         {"recompute-qkv",      Options.RecomputeQKV},
         {"recompute-att",      Options.RecomputeAtt},
         {"recompute-block",    Options.RecomputeBlock},
+        {"lm-head-chunks",     Options.LMHeadChunks},
+        {"attn-bwd-chunks",    Options.AttBwdChunks},
         {"offload-master",     Options.OffloadMaster},
         {"offload-quants",     Options.OffloadQuants},
         {"offload-opt-m",      Options.OffloadOptM},


### PR DESCRIPTION
The workspace size needed for deterministic attention backward in cudnn grows with increasing batch size, and can become the largest tensor when logits are chunked.
This can be prevented by also chunking the calculation of backward attention.