### PR TITLE
Act stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(llmq-common SHARED
         src/utilities/tensor.cpp
         src/utilities/sol.cpp
         src/utilities/dtype.cpp
+        src/utilities/stack.cpp
 
         src/training/dataloader.cpp
         src/training/logging.cpp

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -344,10 +344,10 @@ NB_MODULE(_pyllmq, m) {
             new (d) DataLoader(file_list, chunk_size, 0, 1, seed);
         }, nb::arg("file_list"), nb::arg("chunk_size"), nb::arg("seed") = 42)
         .def("load_batch", [](DataLoader* d, TokenArray inputs, TokenArray targets) {
-            Tensor inp_t{ETensorDType::INT32, {static_cast<long>(inputs.shape(0)), static_cast<long>(inputs.shape(1)), 1, 1, 1},
-                        reinterpret_cast<std::byte*>(inputs.data())};
-            Tensor tgt_t{ETensorDType::INT32, {static_cast<long>(targets.shape(0)), static_cast<long>(targets.shape(1)), 1, 1, 1},
-                        reinterpret_cast<std::byte*>(targets.data())};
+            Tensor inp_t{ETensorDType::INT32, {static_cast<long>(inputs.shape(0)), static_cast<long>(inputs.shape(1))},
+                        reinterpret_cast<std::byte*>(inputs.data()), nullptr, 2, inputs.device_id()};
+            Tensor tgt_t{ETensorDType::INT32, {static_cast<long>(targets.shape(0)), static_cast<long>(targets.shape(1))},
+                        reinterpret_cast<std::byte*>(targets.data()), nullptr, 2, inputs.device_id()};
             d->load_batch(inp_t, tgt_t);
         }, nb::arg("inputs"), nb::arg("targets"),
              "Fill inputs and targets with the next batch of data")

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -593,13 +593,21 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
 
     // backward the 2nd matmul of MLP
     // note that _recompute_block guarantees that if SwiGLu is already quantized (if necessary)
+    rs->temp_acquire(d_acts.DSwiGLU);
     backward_qmm(d_acts.DSwiGLU, d_weights.MLP_Down_w, std::nullopt, d_acts.DResFFN, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
                  accumulate, *rs, B, T, D, C, true, main_stream);
 
     swiglu_backward(d_acts.DMlpUp.Value, d_acts.DSwiGLU, acts.MlpUp, quant_abs_max_ptr(d_acts.DMlpUp), B, T, D, main_stream);
+    rs->temp_free(d_acts.DSwiGLU);
 
+    if(d_acts.DMlpUp.Quant.has_value()) {
+        rs->temp_acquire(d_acts.DMlpUp.Quant.value());
+    }
     backward_qmm(d_acts.DLN2, d_weights.MLP_Up_w, std::nullopt, d_acts.DMlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
                  accumulate, *rs, B, T, C, 2 * D, !rs->Options.RecomputeRMSNorm, main_stream);
+    if(d_acts.DMlpUp.Quant.has_value()) {
+        rs->temp_free(d_acts.DMlpUp.Quant.value());
+    }
 
     // rmsnorm backward does += to the dresidual, so it correctly accumulates grad from the MLP block above
     rmsnorm_backward(d_acts.DResAtt.Value, d_weights.LN2_w, rs->RMSNormScratch, d_acts.DResFFN.Value, d_acts.DLN2,
@@ -609,6 +617,7 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
                  accumulate, *rs, B, T, C, C, false, main_stream);
 
+    rs->temp_acquire(d_acts.DQKV.Value);
     rs->temp_acquire(rs->CuDNNWorkspace);
     for (int i=0; i < Options.AttBwdChunks; ++i) {
         long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
@@ -629,6 +638,7 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
 
     backward_qmm(d_acts.DLN1, d_weights.Attn_QKV_w, d_weights.Attn_QKV_b, d_acts.DQKV, acts.LN1, weights.Attn_QKV_w, rs->MatmulBiasScratch,
                  accumulate, *rs, B, T, C, Config.qkv_channels(), !recompute_ln1, main_stream);
+    rs->temp_free(d_acts.DQKV.Value);
 }
 
 void LLamaModel::_reduce_loss(LLamaRunState& acts, NCCLCommunicator& comm, int B, int T) {

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -242,6 +242,7 @@ float LLamaModel::validate(Tensor inputs, Tensor targets, NCCLCommunicator& comm
     long nano_batches = Options.LMHeadChunks;
     int nano_batch_size = div_exact(B * T, nano_batches);
     Parameters->gather_head(comm);
+    rs->temp_acquire(rs->Output);
     for(int nano_step = 0; nano_step < nano_batches; nano_step++) {
         Tensor lnf_slice = rs->LNF;
         lnf_slice.Data += nano_step * nano_batch_size * C * get_dtype_size(lnf_slice.DType);
@@ -256,6 +257,7 @@ float LLamaModel::validate(Tensor inputs, Tensor targets, NCCLCommunicator& comm
         // accumulate the losses inside rs->losses, and kick off the backward pass inside the fused classifier
         fused_classifier(rs->Output, losses, d_loss, tgt, nano_batch_size, V, Vp, true, main_stream);
     }
+    rs->temp_free(rs->Output);
     Parameters->release_head(main_stream);
     _reduce_loss(*rs, comm, B, T);
 
@@ -450,6 +452,7 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
 
     NvtxRange classifier_and_loss_range("lm-head");
     Parameters->gather_head(comm);
+    rs->temp_acquire(rs->Output);
     for (int nano_step = 0; nano_step < nano_batches; nano_step++) {
         Tensor lnf_slice = rs->LNF;
         lnf_slice.Data += nano_step * nano_batch_size * C * get_dtype_size(lnf_slice.DType);
@@ -493,6 +496,7 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
                rs->CublasLtHandle, rs->CuBlasWorkspace, C, nano_batch_size, V, EMMTranspose::NN, false, main_stream);
 
     }
+    rs->temp_free(rs->Output);
     Parameters->release_head(main_stream);
 }
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -181,20 +181,20 @@ void LLamaModel::_forward_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLayer
 
     // 1) projection to QKV vectors (note k,v may be fewer heads than q)
     forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
-                rs->CublasLtHandle, rs->Workspace,
+                rs->CublasLtHandle, rs->CuBlasWorkspace,
                 B, T, C, Config.qkv_channels(),
                 rs->DeviceProp, false, main_stream);
     // 2) apply RoPE to q,k (potentially in place)
     rope_forward(acts.QKV, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
     // 3) attention: att <- softmax(qk^T)v
-    attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.QKV, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
+    attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.QKV, rs->CuBlasWorkspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
     // quantize attention if necessary
     if(acts.Att.Quant.has_value()) {
         abs_max(acts.Att.Quant->Scales, acts.Att.Value, acts.Att.Value.nelem(), rs->DeviceProp, main_stream);
     }
 
     forward_qmm(acts.AttO, acts.Att, weights.Attn_Out_w, std::nullopt,
-                rs->CublasLtHandle, rs->Workspace,
+                rs->CublasLtHandle, rs->CuBlasWorkspace,
                 B, T, C, C,
                 rs->DeviceProp, false, main_stream);
 
@@ -202,13 +202,13 @@ void LLamaModel::_forward_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLayer
                                    quant_abs_max_ptr(acts.LN2), Config.RmsNormEps, B * T, C, main_stream);
 
     forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
-                rs->CublasLtHandle, rs->Workspace,
+                rs->CublasLtHandle, rs->CuBlasWorkspace,
                 B, T, C, 2 * D,
                 rs->DeviceProp, false, main_stream);
     swiglu_forward(acts.SwiGLu.Value, acts.MlpUp, quant_abs_max_ptr(acts.SwiGLu), B, T, D, main_stream);
 
     forward_qmm(acts.MlpDown, acts.SwiGLu, weights.MLP_Down_w, std::nullopt,
-                rs->CublasLtHandle, rs->Workspace,
+                rs->CublasLtHandle, rs->CuBlasWorkspace,
                 B, T, D, C,
                 rs->DeviceProp, false, main_stream);
 }
@@ -251,7 +251,7 @@ float LLamaModel::validate(Tensor inputs, Tensor targets, NCCLCommunicator& comm
         losses.Data += nano_step * nano_batch_size * get_dtype_size(losses.DType);
 
         matmul(rs->Output, Parameters->get_head(main_stream), lnf_slice,
-               std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, V, nano_batch_size, C, EMMTranspose::TN, false, main_stream);
+               std::nullopt, nullptr, rs->CublasLtHandle, rs->CuBlasWorkspace, V, nano_batch_size, C, EMMTranspose::TN, false, main_stream);
 
         // accumulate the losses inside rs->losses, and kick off the backward pass inside the fused classifier
         fused_classifier(rs->Output, losses, d_loss, tgt, nano_batch_size, V, Vp, true, main_stream);
@@ -271,8 +271,8 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
                   int B, int T, int C, int OC,
                   bool reuse_inp, cudaStream_t stream) {
     if (weight.DType == inp.Value.DType) {
-        matmul(dinp, weight, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::NN, false, stream);
-        matmul(dweight, inp.Value, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::NT, accumulate_gradient, stream);
+        matmul(dinp, weight, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.CuBlasWorkspace, C, B*T, OC, EMMTranspose::NN, false, stream);
+        matmul(dweight, inp.Value, dout.Value, std::nullopt, nullptr, rs.CublasLtHandle, rs.CuBlasWorkspace, C, OC, B*T, EMMTranspose::NT, accumulate_gradient, stream);
 
         if (dbias.has_value()) {
             backward_bias(dbias.value(), dout.Value, nullptr, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
@@ -283,8 +283,8 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
             quantize_with_abs_max(inp.Quant.value(), inp.Value, nullptr, B*T*C, rs.DeviceProp, stream);
         }
 
-        matmul(dinp, weight, dout.Quant.value(), std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::NN, false, stream);
-        matmul(dweight, inp.Quant.value(), dout.Quant.value(), std::nullopt, nullptr, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::NT, accumulate_gradient, stream);
+        matmul(dinp, weight, dout.Quant.value(), std::nullopt, nullptr, rs.CublasLtHandle, rs.CuBlasWorkspace, C, B*T, OC, EMMTranspose::NN, false, stream);
+        matmul(dweight, inp.Quant.value(), dout.Quant.value(), std::nullopt, nullptr, rs.CublasLtHandle, rs.CuBlasWorkspace, C, OC, B*T, EMMTranspose::NT, accumulate_gradient, stream);
 
         if (dbias.has_value()) {
             backward_bias(dbias.value(), dout.Value, nullptr, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
@@ -311,7 +311,7 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
         matmul_out_scale(dinp_scale, dout_scale, wgt_scale, 1.f / scale / scale, stream);
         matmul_out_scale(dwgt_scale, dout_scale, act_scale, 1.f / scale / scale, stream);
 
-        matmul(dinp, weight_tp, dout.Quant.value(), std::nullopt, dinp_scale, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::TN, false, stream);
+        matmul(dinp, weight_tp, dout.Quant.value(), std::nullopt, dinp_scale, rs.CublasLtHandle, rs.CuBlasWorkspace, C, B*T, OC, EMMTranspose::TN, false, stream);
         rs.temp_free(weight_tp);
 
         auto activation_tp = rs.temp_alloc(inp_q.DType, {C, B*T});
@@ -325,7 +325,7 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
             quantize_and_transpose_with_abs_max(activation_tp, inp.Value, act_scale, B*T, C, rs.DeviceProp, stream);
         }
         transpose(grad_tp, dout.Quant.value(), B*T, OC, stream);
-        matmul(dweight, activation_tp, grad_tp, std::nullopt, dwgt_scale, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::TN, accumulate_gradient, stream);
+        matmul(dweight, activation_tp, grad_tp, std::nullopt, dwgt_scale, rs.CublasLtHandle, rs.CuBlasWorkspace, C, OC, B*T, EMMTranspose::TN, accumulate_gradient, stream);
         if (dbias.has_value()) {
             backward_bias(dbias.value(), dout.Quant.value(), dout_scale, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
         }
@@ -461,7 +461,7 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
         dlnf_slice.Data += nano_step * nano_batch_size * C * get_dtype_size(dlnf_slice.DType);
 
         matmul(rs->Output, Parameters->get_head(main_stream), lnf_slice,
-               std::nullopt, nullptr, rs->CublasLtHandle, rs->Workspace, V, nano_batch_size, C, EMMTranspose::TN,
+               std::nullopt, nullptr, rs->CublasLtHandle, rs->CuBlasWorkspace, V, nano_batch_size, C, EMMTranspose::TN,
                false, main_stream);
 
         // accumulate the losses inside rs->losses, and kick off the backward pass inside the fused classifier
@@ -482,7 +482,7 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
         auto& d_lmhead = Grads->get_lmhead_full(main_stream, comm, accumulate);
         accumulate |= nano_step != 0;
         matmul(d_lmhead, lnf_slice, rs->Output, std::nullopt, get_device_one(),
-               rs->CublasLtHandle, rs->Workspace, C, V, nano_batch_size, EMMTranspose::NT, accumulate, main_stream);
+               rs->CublasLtHandle, rs->CuBlasWorkspace, C, V, nano_batch_size, EMMTranspose::NT, accumulate, main_stream);
         if (nano_step == nano_batches - 1) {
             Grads->notify_lmhead(main_stream, comm);
         }
@@ -490,7 +490,7 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
         // for some reason, we cannot set scale == nullptr here ?!
         // so instead supply the value one (get_device_one())
         matmul(dlnf_slice, Parameters->get_head(main_stream), rs->Output, std::nullopt, get_device_one(),
-               rs->CublasLtHandle, rs->Workspace, C, nano_batch_size, V, EMMTranspose::NN, false, main_stream);
+               rs->CublasLtHandle, rs->CuBlasWorkspace, C, nano_batch_size, V, EMMTranspose::NN, false, main_stream);
 
     }
     Parameters->release_head(main_stream);
@@ -529,19 +529,19 @@ void LLamaModel::_recompute_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLay
         //                2) we recompute RMSNorm; then, acts.LN1 will be correct, but its quantized version will not, so
         //                   we have to re-quantize
         forward_qmm(acts.QKV, acts.LN1, weights.Attn_QKV_w, weights.Attn_QKV_b,
-                     rs->CublasLtHandle, rs->Workspace,
+                     rs->CublasLtHandle, rs->CuBlasWorkspace,
                      B, T, C, Config.qkv_channels(),
                      rs->DeviceProp, !recompute_ln1, main_stream);
         rope_forward(acts.QKV, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
     }
 
     if (recompute_att) {
-        attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.QKV, rs->Workspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
+        attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.QKV, rs->CuBlasWorkspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
         // AttO not needed in backward pass; but if we want to recompute the entire transformer block, we need its output
         // to recompute the FFN part
         if (opt.RecomputeBlock) {
             forward_qmm(acts.AttO, acts.Att, weights.Attn_Out_w, std::nullopt,
-                         rs->CublasLtHandle, rs->Workspace,
+                         rs->CublasLtHandle, rs->CuBlasWorkspace,
                          B, T, C, C,
                          rs->DeviceProp, false, main_stream);
         }
@@ -560,7 +560,7 @@ void LLamaModel::_recompute_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLay
 
     if(opt.RecomputeFFN) {
         forward_qmm(acts.MlpUp, acts.LN2, weights.MLP_Up_w, std::nullopt,
-                         rs->CublasLtHandle, rs->Workspace,
+                         rs->CublasLtHandle, rs->CuBlasWorkspace,
                          B, T, C, 2 * D,
                          rs->DeviceProp, false, main_stream);
     }
@@ -605,6 +605,7 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
     backward_qmm(d_acts.DAttY, d_weights.Attn_Out_w, std::nullopt, d_acts.DResAtt, acts.Att, weights.Attn_Out_w, std::nullopt,
                  accumulate, *rs, B, T, C, C, false, main_stream);
 
+    rs->temp_acquire(rs->CuDNNWorkspace);
     for (int i=0; i < Options.AttBwdChunks; ++i) {
         long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
         Tensor d_qkv = shard_view(d_acts.DQKV.Value, i, Options.AttBwdChunks);
@@ -612,9 +613,10 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
         Tensor att = shard_view(acts.Att.Value, i, Options.AttBwdChunks);
         Tensor d_atty = shard_view(d_acts.DAttY, i, Options.AttBwdChunks);
         Tensor qkv = shard_view(acts.QKV, i, Options.AttBwdChunks);
-        attention_backward_cudnn(d_qkv, lse, att, d_atty, qkv, rs->Workspace, rs->CudnnHandle,
+        attention_backward_cudnn(d_qkv, lse, att, d_atty, qkv, rs->CuDNNWorkspace, rs->CudnnHandle,
             chunk_batch_size, T, Hq, Hkv, Hs, main_stream);
     }
+    rs->temp_free(rs->CuDNNWorkspace);
     rope_backward(d_acts.DQKV.Value, d_acts.DQKV.Value, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
 
     if (d_acts.DQKV.Quant.has_value()) {

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -298,15 +298,9 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
 
         quantize_with_abs_max(dout.Quant.value(), dout.Value, dout_scale, B*T*OC, rs.DeviceProp, stream);
 
-        if(reuse_inp) {
-            // inp is already quantized from the forward pass, so just transpose here
-            transpose(rs.ActivationTranspose, inp.Quant.value(), B*T, C, stream);
-        } else {
-            // even though we're re-using (and overwriting) the main tensor, each tensor still has its own version
-            // of the absmax-scale, so we can reuse the existing scale from the forward pass
-            quantize_and_transpose_with_abs_max(rs.ActivationTranspose, inp.Value, act_scale, B*T, C, rs.DeviceProp, stream);
-        }
-        transpose(rs.WeightTranspose, weight, OC, C, stream);
+        auto& inp_q = inp.Quant.value();
+        auto weight_tp = rs.temp_alloc(inp_q.DType, {C, OC});
+        transpose(weight_tp, weight, OC, C, stream);
 
         float scale = 1.f;
         switch(weight.DType) {
@@ -317,13 +311,26 @@ void backward_qmm(Tensor& dinp, Tensor& dweight, std::optional<Tensor> dbias,
         matmul_out_scale(dinp_scale, dout_scale, wgt_scale, 1.f / scale / scale, stream);
         matmul_out_scale(dwgt_scale, dout_scale, act_scale, 1.f / scale / scale, stream);
 
-        matmul(dinp, rs.WeightTranspose, dout.Quant.value(), std::nullopt, dinp_scale, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::TN, false, stream);
+        matmul(dinp, weight_tp, dout.Quant.value(), std::nullopt, dinp_scale, rs.CublasLtHandle, rs.Workspace, C, B*T, OC, EMMTranspose::TN, false, stream);
+        rs.temp_free(weight_tp);
 
-        transpose(rs.GradientTranspose, dout.Quant.value(), B*T, OC, stream);
-        matmul(dweight, rs.ActivationTranspose, rs.GradientTranspose, std::nullopt, dwgt_scale, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::TN, accumulate_gradient, stream);
+        auto activation_tp = rs.temp_alloc(inp_q.DType, {C, B*T});
+        auto grad_tp = rs.temp_alloc(rs.Options.grad_dtype(), {OC, B*T});
+        if(reuse_inp) {
+            // inp is already quantized from the forward pass, so just transpose here
+            transpose(activation_tp, inp_q, B*T, C, stream);
+        } else {
+            // even though we're re-using (and overwriting) the main tensor, each tensor still has its own version
+            // of the absmax-scale, so we can reuse the existing scale from the forward pass
+            quantize_and_transpose_with_abs_max(activation_tp, inp.Value, act_scale, B*T, C, rs.DeviceProp, stream);
+        }
+        transpose(grad_tp, dout.Quant.value(), B*T, OC, stream);
+        matmul(dweight, activation_tp, grad_tp, std::nullopt, dwgt_scale, rs.CublasLtHandle, rs.Workspace, C, OC, B*T, EMMTranspose::TN, accumulate_gradient, stream);
         if (dbias.has_value()) {
             backward_bias(dbias.value(), dout.Quant.value(), dout_scale, bias_buffer.value(), B, T, OC, rs.DeviceProp, stream);
         }
+        rs.temp_free(grad_tp);
+        rs.temp_free(activation_tp);
     }
 }
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -275,7 +275,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     FreqCis = builder.generate_frequencies();
     // We're chunking the logit computation, so we can allocate a much smaller tensor.
     long out_size = div_exact(B*T, (long)Options.LMHeadChunks);
-    Output = alloc->allocate(config.DType, "output", {out_size, V});
+    Output = Tensor{config.DType,{out_size, V}, nullptr, nullptr, 2, Inputs.Device};
     LNF = alloc->allocate(config.DType, "lnf", {B, T, C});
     LNF_Rstd = alloc->allocate(ETensorDType::FP32, "lnf_rstd", {B, T});
     DLNF = alloc->allocate(config.DType, "d_lnf", {B, T, C});
@@ -393,6 +393,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     activation_stack.free(activation_stack.allocate(CuDNNWorkspace.bytes()));   // attention
     bw_qmm(B, T, H, C);         // backward qmm swiglu
     bw_qmm(B, T, C, 2 * H);     // backward qmm up
+    activation_stack.free(activation_stack.allocate(Output.bytes()));  // lm-head
 
     long required_size = activation_stack.max_utilization();
     mTempStack = DeviceMemoryStack{alloc->allocate(ETensorDType::BYTE, "temporaries", {required_size}).Data, (std::size_t)required_size, Inputs.Device};

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -254,15 +254,13 @@ void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
     CUDA_CHECK(cudaEventRecord(status.Event, main_stream));
 }
 
-void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
-    Options = options;
-    Allocator = alloc;
-
+void LLamaRunState::init(LLamaConfig config, long B, long T) {
     long V = config.VocabSize;
     long C = config.HiddenSize;
     long H = config.IntermediateSize;
+    auto& alloc = Allocator;
 
-    RunStateBuilder builder(config, options, B, T, alloc);
+    RunStateBuilder builder(config, Options, B, T, alloc);
 
     int did;
     CUDA_CHECK(cudaGetDevice(&did));
@@ -276,7 +274,7 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
     Encoded = alloc->allocate(config.DType, "encoded", {B, T, C});
     FreqCis = builder.generate_frequencies();
     // We're chunking the logit computation, so we can allocate a much smaller tensor.
-    long out_size = div_exact(B*T, (long)options.LMHeadChunks);
+    long out_size = div_exact(B*T, (long)Options.LMHeadChunks);
     Output = alloc->allocate(config.DType, "output", {out_size, V});
     LNF = alloc->allocate(config.DType, "lnf", {B, T, C});
     LNF_Rstd = alloc->allocate(ETensorDType::FP32, "lnf_rstd", {B, T});
@@ -286,7 +284,7 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
     CudnnHandle = create_cudnn_handle();
 
     // batch size for chunked attention backward
-    long chunk_batch_size = div_exact(B, (long)options.AttBwdChunks);
+    long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
     long ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
     ws_size = std::max(ws_size, 32l * 1024 * 1024); // Hardcoding workspace to 32MiB but only Hopper needs 32 (for others 4 is OK)
     CublasLtHandle = create_cublaslt_handle();
@@ -297,7 +295,7 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
 
     Acts = builder.allocate_forward_buffers(LNF);
     ResidualsAreReady = create_named_event("residual_ready");
-    if(options.OffloadResidual) {
+    if(Options.OffloadResidual) {
         DeviceResiduals.reserve(2);
         OffloadedResiduals.reserve(config.NumLayers);
         for(int i = 0; i < 2; ++i) {
@@ -323,10 +321,10 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
     EncoderBwdIndices = alloc->allocate(ETensorDType::INT32, "enc_bw_idx", EAllocationType::PINNED, {B, T, num_c_groups});
     EncoderBwdInfo = alloc->allocate(ETensorDType::INT32, "env_bw_info", EAllocationType::PINNED, {B, T, 4 * num_c_groups});
 
-    if(options.grad_dtype() == ETensorDType::FP8_E4M3 || options.grad_dtype() == ETensorDType::FP8_E5M2) {
+    if(Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2) {
         WeightTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "wgt_tp_buffer", {config.HiddenSize, 2 * config.IntermediateSize});
         ActivationTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "act_tp_buffer", {H, B, T});
-        GradientTranspose = alloc->allocate(options.grad_dtype(), "grd_tp_buffer", {2*H, B, T});
+        GradientTranspose = alloc->allocate(Options.grad_dtype(), "grd_tp_buffer", {2*H, B, T});
     }
 
     NormBuffer = alloc->allocate(ETensorDType::FP32, "norm_buffer", {get_max_num_block_sums(DeviceProp)});;
@@ -356,7 +354,7 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
         DActs[i].DMlpUp.Value = Acts[i].MlpUp;
     }
 
-    if(options.matmul_dtype() != config.DType) {
+    if(Options.matmul_dtype() != config.DType) {
         AbsMaxes = alloc->allocate(ETensorDType::FP32, "abs_max", {config.NumLayers, 6l*QWEN2_NUM_LINEAR_OPS});
         float* abs_max_ptr = AbsMaxes->get<float>();
         for(int i = 0; i < config.NumLayers; ++i) {
@@ -388,8 +386,8 @@ void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long 
 }
 
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
-    LLamaRunState state;
-    state.init(config, options, B, T, alloc);
+    LLamaRunState state{options, std::move(alloc)};
+    state.init(config, B, T);
     return state;
 }
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -321,12 +321,6 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     EncoderBwdIndices = alloc->allocate(ETensorDType::INT32, "enc_bw_idx", EAllocationType::PINNED, {B, T, num_c_groups});
     EncoderBwdInfo = alloc->allocate(ETensorDType::INT32, "env_bw_info", EAllocationType::PINNED, {B, T, 4 * num_c_groups});
 
-    if(Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2) {
-        WeightTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "wgt_tp_buffer", {config.HiddenSize, 2 * config.IntermediateSize});
-        ActivationTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "act_tp_buffer", {H, B, T});
-        GradientTranspose = alloc->allocate(Options.grad_dtype(), "grd_tp_buffer", {2*H, B, T});
-    }
-
     NormBuffer = alloc->allocate(ETensorDType::FP32, "norm_buffer", {get_max_num_block_sums(DeviceProp)});;
     Tensor host_buffer = alloc->allocate(ETensorDType::FP32, "host_buffer", EAllocationType::PINNED, {2});
     NormHost = host_buffer.get<float>();
@@ -382,6 +376,27 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
         }
     }
 
+    // create a dummy stack and simulate the way we're going to use temporaries later, to determine how much we need to allocate
+    DeviceMemoryStack activation_stack(nullptr, 1024*1024*1024*1024ll, Inputs.Device);
+
+    auto bw_qmm = [&](int B, int T, int C, int OC) {
+        if(Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2) {
+            auto wgt_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, OC});
+            activation_stack.free(wgt_tp.Data);
+            auto act_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, B * T});
+            auto grd_tp = activation_stack.allocate(Options.grad_dtype(), {OC, B * T});
+            activation_stack.free(grd_tp.Data);
+            activation_stack.free(act_tp.Data);
+        }
+    };
+
+    // simulate to determine required stack size
+    bw_qmm(B, T, H, C);         // backward qmm swiglu
+    bw_qmm(B, T, C, 2 * H);     // backward qmm up
+
+    long required_size = activation_stack.max_utilization();
+    mTempStack = DeviceMemoryStack{alloc->allocate(ETensorDType::BYTE, "temporaries", {required_size}).Data, (std::size_t)required_size, Inputs.Device};
+
     MatmulScales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
 }
 
@@ -392,7 +407,7 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long 
 }
 
 Tensor LLamaRunState::temp_alloc(ETensorDType dtype, const std::vector<long>& shape) {
-    return mTempStack.allocate(dtype, shape);
+    return  mTempStack.allocate(dtype, shape);
 }
 
 void LLamaRunState::temp_acquire(Tensor& target) {
@@ -424,4 +439,3 @@ Tensor& get_input_buffer(LLamaRunState& acts) {
 Tensor& get_target_buffer(LLamaRunState& acts) {
     return acts.Targets_CPU;
 }
-

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -254,10 +254,10 @@ void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
     CUDA_CHECK(cudaEventRecord(status.Event, main_stream));
 }
 
-LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
-    // we are *not* handling this as a single giant allocation
-    // by using independent allocations, we give sanitizers a better chance of catching errors,
-    // and we never have to worry about tensor alignment
+void LLamaRunState::init(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
+    Options = options;
+    Allocator = alloc;
+
     long V = config.VocabSize;
     long C = config.HiddenSize;
     long H = config.IntermediateSize;
@@ -266,147 +266,131 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long 
 
     int did;
     CUDA_CHECK(cudaGetDevice(&did));
-    cudaDeviceProp deviceProp;
-    CUDA_CHECK(cudaGetDeviceProperties(&deviceProp, did));
+    CUDA_CHECK(cudaGetDeviceProperties(&DeviceProp, did));
 
-    Tensor inputs = alloc->allocate(ETensorDType::INT32, "inputs", {B, T});
-    Tensor targets = alloc->allocate(ETensorDType::INT32, "targets", {B, T});
-    Tensor inputs_cpu = alloc->allocate(ETensorDType::INT32, "inputs_cpu", EAllocationType::PINNED, {B, T});
-    Tensor targets_cpu = alloc->allocate(ETensorDType::INT32, "targets_cpu", EAllocationType::PINNED, {B, T});
-    Tensor losses = alloc->allocate(ETensorDType::FP32, "losses", {B, T});
-    Tensor encoded = alloc->allocate(config.DType, "encoded", {B, T, C});
-    Tensor freq_cis = builder.generate_frequencies();
+    Inputs = alloc->allocate(ETensorDType::INT32, "inputs", {B, T});
+    Targets = alloc->allocate(ETensorDType::INT32, "targets", {B, T});
+    Inputs_CPU = alloc->allocate(ETensorDType::INT32, "inputs_cpu", EAllocationType::PINNED, {B, T});
+    Targets_CPU = alloc->allocate(ETensorDType::INT32, "targets_cpu", EAllocationType::PINNED, {B, T});
+    Losses = alloc->allocate(ETensorDType::FP32, "losses", {B, T});
+    Encoded = alloc->allocate(config.DType, "encoded", {B, T, C});
+    FreqCis = builder.generate_frequencies();
     // We're chunking the logit computation, so we can allocate a much smaller tensor.
     long out_size = div_exact(B*T, (long)options.LMHeadChunks);
-    Tensor output = alloc->allocate(config.DType, "output", {out_size, V});
-    Tensor lnf = alloc->allocate(config.DType, "lnf", {B, T, C});
-    Tensor lnf_rstd = alloc->allocate(ETensorDType::FP32, "lnf_rstd", {B, T});
-    Tensor d_lnf = alloc->allocate(config.DType, "d_lnf", {B, T, C});
-    long rms_scratch_size = get_rmsnorm_backward_scratch_size(C, deviceProp);
-    long bias_scratch_size = get_bias_backward_scratch_size(config.DType, config.qkv_channels(), deviceProp);
-    cudnnHandle_t cudnn_handle = create_cudnn_handle();
+    Output = alloc->allocate(config.DType, "output", {out_size, V});
+    LNF = alloc->allocate(config.DType, "lnf", {B, T, C});
+    LNF_Rstd = alloc->allocate(ETensorDType::FP32, "lnf_rstd", {B, T});
+    DLNF = alloc->allocate(config.DType, "d_lnf", {B, T, C});
+    long rms_scratch_size = get_rmsnorm_backward_scratch_size(C, DeviceProp);
+    long bias_scratch_size = get_bias_backward_scratch_size(config.DType, config.qkv_channels(), DeviceProp);
+    CudnnHandle = create_cudnn_handle();
 
     // batch size for chunked attention backward
     long chunk_batch_size = div_exact(B, (long)options.AttBwdChunks);
-    long ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), cudnn_handle);
+    long ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
     ws_size = std::max(ws_size, 32l * 1024 * 1024); // Hardcoding workspace to 32MiB but only Hopper needs 32 (for others 4 is OK)
-    cublasLtHandle_t cublas_handle = create_cublaslt_handle();
-    Tensor rms_scratch = alloc->allocate(ETensorDType::BYTE, "rms_scratch", {rms_scratch_size});
-    Tensor bias_scratch = alloc->allocate(ETensorDType::FP32, "bias_scratch", {bias_scratch_size / (long)sizeof(float)});
-    Tensor cudnn_ws = alloc->allocate(ETensorDType::BYTE, "workspace", {ws_size});
-    Tensor d_emb = alloc->allocate(config.DType, "d_emb", {B, T, C});
+    CublasLtHandle = create_cublaslt_handle();
+    RMSNormScratch = alloc->allocate(ETensorDType::BYTE, "rms_scratch", {rms_scratch_size});
+    MatmulBiasScratch = alloc->allocate(ETensorDType::FP32, "bias_scratch", {bias_scratch_size / (long)sizeof(float)});
+    Workspace = alloc->allocate(ETensorDType::BYTE, "workspace", {ws_size});
+    DEmb = alloc->allocate(config.DType, "d_emb", {B, T, C});
 
-    auto layers = builder.allocate_forward_buffers(lnf);
-    std::vector<Tensor> device_residuals;
-    std::vector<Tensor> offloaded_residuals;
-    std::vector<LLamaRunState::sOffloadedResidualState> offloaded_residual_states;
-    cudaEvent_t residual_ready_event = create_named_event("residual_ready");
+    Acts = builder.allocate_forward_buffers(LNF);
+    ResidualsAreReady = create_named_event("residual_ready");
     if(options.OffloadResidual) {
-        device_residuals.reserve(2);
-        offloaded_residuals.reserve(config.NumLayers);
+        DeviceResiduals.reserve(2);
+        OffloadedResiduals.reserve(config.NumLayers);
         for(int i = 0; i < 2; ++i) {
-            device_residuals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
-            offloaded_residual_states.emplace_back(
+            DeviceResiduals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
+            OffloadedResidualState.emplace_back(
                 create_named_event((std::string("offload_res_ffn_") + std::to_string(i)).c_str()),
                 -1, false
-                );
+            );
         }
         for(int i = 0; i < config.NumLayers; ++i) {
-            offloaded_residuals.push_back(
+            OffloadedResiduals.push_back(
                 alloc->allocate(config.DType, "ffn-res-off", EAllocationType::PINNED, {B, T, C}));
         }
     } else {
-        device_residuals.reserve(config.NumLayers);
+        DeviceResiduals.reserve(config.NumLayers);
         for(int i = 0; i < config.NumLayers; ++i) {
-            device_residuals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
+            DeviceResiduals.emplace_back(alloc->allocate(config.DType, "res_ffn", {B, T, C}));
         }
     }
 
     long num_c_groups = div_ceil(C, (long)(16 / get_dtype_size(config.DType) * 32));
-    Tensor enc_bw_scratch = alloc->allocate(ETensorDType::INT32, "enc_bw_scratch", {B, T, num_c_groups * 5});
-    Tensor enc_bw_idx = alloc->allocate(ETensorDType::INT32, "enc_bw_idx", EAllocationType::PINNED, {B, T, num_c_groups});
-    Tensor env_bw_info = alloc->allocate(ETensorDType::INT32, "env_bw_info", EAllocationType::PINNED, {B, T, 4 * num_c_groups});
+    EncoderBwdScratch = alloc->allocate(ETensorDType::INT32, "enc_bw_scratch", {B, T, num_c_groups * 5});
+    EncoderBwdIndices = alloc->allocate(ETensorDType::INT32, "enc_bw_idx", EAllocationType::PINNED, {B, T, num_c_groups});
+    EncoderBwdInfo = alloc->allocate(ETensorDType::INT32, "env_bw_info", EAllocationType::PINNED, {B, T, 4 * num_c_groups});
 
-    Tensor wgt_tp_buffer;
-    Tensor act_tp_buffer;
-    Tensor grd_tp_buffer;
     if(options.grad_dtype() == ETensorDType::FP8_E4M3 || options.grad_dtype() == ETensorDType::FP8_E5M2) {
-        wgt_tp_buffer = alloc->allocate(ETensorDType::FP8_E4M3, "wgt_tp_buffer", {config.HiddenSize, 2 * config.IntermediateSize});
-        act_tp_buffer = alloc->allocate(ETensorDType::FP8_E4M3, "act_tp_buffer", {H, B, T});
-        grd_tp_buffer = alloc->allocate(options.grad_dtype(), "grd_tp_buffer", {2*H, B, T});
-    } else {
-        // no TP buffers needed
+        WeightTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "wgt_tp_buffer", {config.HiddenSize, 2 * config.IntermediateSize});
+        ActivationTranspose = alloc->allocate(ETensorDType::FP8_E4M3, "act_tp_buffer", {H, B, T});
+        GradientTranspose = alloc->allocate(options.grad_dtype(), "grd_tp_buffer", {2*H, B, T});
     }
 
-    Tensor norm_buffer = alloc->allocate(ETensorDType::FP32, "norm_buffer", {get_max_num_block_sums(deviceProp)});
+    NormBuffer = alloc->allocate(ETensorDType::FP32, "norm_buffer", {get_max_num_block_sums(DeviceProp)});;
     Tensor host_buffer = alloc->allocate(ETensorDType::FP32, "host_buffer", EAllocationType::PINNED, {2});
+    NormHost = host_buffer.get<float>();
+    LossHost = host_buffer.get<float>() + 1;
 
-    cudaStream_t main_stream = create_named_stream("main stream");
-    cudaStream_t side_stream = create_named_stream("side stream");
+    MainStream = create_named_stream("main stream");
+    SideStream = create_named_stream("side stream");
 
-    cudaEvent_t side_stream_event = create_named_event("side stream event");
+    SideStreamEvent = create_named_event("side stream event");
 
-    cudaEvent_t forward_done_event = create_named_event("forward done");
-    cudaEvent_t backward_done_event = create_named_event("backward done");
-    cudaEvent_t norm_done_event = create_named_event("norm done");
-    cudaEvent_t lmhead_done = create_named_event("optimizer lmhead done");
-    cudaEvent_t optimizer_done_event = create_named_event("optimizer done");
-    cudaEvent_t transfer_done_event = create_named_event("transfer done");
+    ForwardDone = create_named_event("forward done");
+    BackwardDone = create_named_event("backward done");
+    NormDone = create_named_event("norm done");
+    OptEmbeddingsDone = create_named_event("optimizer lmhead done");
+    OptimizerDone = create_named_event("optimizer done");
+    TransferDone = create_named_event("transfer done");
 
-    std::vector<cudaEvent_t> optimizer_events;
     for(int i = 0; i < config.NumLayers + 1; ++i) {
-        optimizer_events.push_back(create_named_event(("opt " + std::to_string(i) + " done").c_str()));
+        LayerUpdateDone.push_back(create_named_event(("opt " + std::to_string(i) + " done").c_str()));
     }
 
-    std::vector<LLamaRunState::LayerGradients> grads = builder.allocate_backward_buffers(d_lnf);
+    DActs = builder.allocate_backward_buffers(DLNF);
     for (int i = 0; i < config.NumLayers; ++i) {
         // DMlpUp is handled in-place
-        grads[i].DMlpUp.Value = layers[i].MlpUp;
+        DActs[i].DMlpUp.Value = Acts[i].MlpUp;
     }
 
-    std::optional<Tensor> abs_maxes;
     if(options.matmul_dtype() != config.DType) {
-        abs_maxes = alloc->allocate(ETensorDType::FP32, "abs_max", {config.NumLayers, 6l*QWEN2_NUM_LINEAR_OPS});
-        float* abs_max_ptr = abs_maxes->get<float>();
+        AbsMaxes = alloc->allocate(ETensorDType::FP32, "abs_max", {config.NumLayers, 6l*QWEN2_NUM_LINEAR_OPS});
+        float* abs_max_ptr = AbsMaxes->get<float>();
         for(int i = 0; i < config.NumLayers; ++i) {
             float* layer_abs_maxes = abs_max_ptr + 6 * QWEN2_NUM_LINEAR_OPS * i;
 
-            layers[i].LN1.Quant->Scales = layer_abs_maxes + 0;
-            layers[i].QKV.Scales = layer_abs_maxes + 2;
-            grads.at(i).DQKV.Quant->Scales = layer_abs_maxes + 3;
-            grads.at(i).DLN1.Scales = layer_abs_maxes + 4;
+            Acts[i].LN1.Quant->Scales = layer_abs_maxes + 0;
+            Acts[i].QKV.Scales = layer_abs_maxes + 2;
+            DActs.at(i).DQKV.Quant->Scales = layer_abs_maxes + 3;
+            DActs.at(i).DLN1.Scales = layer_abs_maxes + 4;
 
-            layers[i].Att.Quant->Scales = layer_abs_maxes + 6;
-            layers[i].AttO.Scales = layer_abs_maxes + 8;
-            grads.at(i).DResAtt.Quant->Scales = layer_abs_maxes + 9;
-            grads.at(i).DAttY.Scales = layer_abs_maxes + 10;
+            Acts[i].Att.Quant->Scales = layer_abs_maxes + 6;
+            Acts[i].AttO.Scales = layer_abs_maxes + 8;
+            DActs.at(i).DResAtt.Quant->Scales = layer_abs_maxes + 9;
+            DActs.at(i).DAttY.Scales = layer_abs_maxes + 10;
 
-            layers[i].LN2.Quant->Scales = layer_abs_maxes + 12;
-            layers[i].MlpUp.Scales = layer_abs_maxes + 14;
-            grads.at(i).DMlpUp.Quant->Scales = layer_abs_maxes + 15;
-            grads.at(i).DLN2.Scales = layer_abs_maxes + 16;
+            Acts[i].LN2.Quant->Scales = layer_abs_maxes + 12;
+            Acts[i].MlpUp.Scales = layer_abs_maxes + 14;
+            DActs.at(i).DMlpUp.Quant->Scales = layer_abs_maxes + 15;
+            DActs.at(i).DLN2.Scales = layer_abs_maxes + 16;
 
-            layers[i].SwiGLu.Quant->Scales = layer_abs_maxes + 18;
-            layers[i].MlpDown.Scales = layer_abs_maxes + 20;
-            grads.at(i).DResFFN.Quant->Scales = layer_abs_maxes + 21;
-            grads.at(i).DSwiGLU.Scales = layer_abs_maxes + 22;
+            Acts[i].SwiGLu.Quant->Scales = layer_abs_maxes + 18;
+            Acts[i].MlpDown.Scales = layer_abs_maxes + 20;
+            DActs.at(i).DResFFN.Quant->Scales = layer_abs_maxes + 21;
+            DActs.at(i).DSwiGLU.Scales = layer_abs_maxes + 22;
         }
     }
 
-    Tensor mm_scales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
+    MatmulScales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
+}
 
-    return LLamaRunState{inputs, targets, inputs_cpu, targets_cpu, losses,
-                         encoded, freq_cis, output, lnf, lnf_rstd, std::move(layers),
-                         std::move(device_residuals), std::move(offloaded_residuals), std::move(offloaded_residual_states),
-                         std::move(grads),
-                         d_lnf, d_emb, rms_scratch, bias_scratch, cudnn_ws, enc_bw_scratch, enc_bw_idx, env_bw_info,
-                         wgt_tp_buffer, act_tp_buffer, grd_tp_buffer,
-                         abs_maxes, mm_scales,
-                         norm_buffer, host_buffer.get<float>(), host_buffer.get<float>() + 1,
-                         options, std::move(alloc), deviceProp, main_stream, side_stream, side_stream_event,
-                         forward_done_event, backward_done_event, transfer_done_event, norm_done_event, lmhead_done,
-                         std::move(optimizer_events), optimizer_done_event, residual_ready_event,
-                         nullptr, nullptr, nullptr, cudnn_handle, cublas_handle};
+LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
+    LLamaRunState state;
+    state.init(config, options, B, T, alloc);
+    return state;
 }
 
 float get_loss(LLamaRunState& acts) {

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -154,11 +154,11 @@ std::vector<LLamaRunState::LayerActivations> RunStateBuilder::allocate_forward_b
 
 LLamaRunState::LayerGradients RunStateBuilder::allocate_basic_bwd_tensors(Tensor d_lnf) {
     QuantizableTensor d_res_ffn{allocate(Config.DType, "d_res_ffn", B, T, C)};
-    Tensor d_swiglu = allocate(Config.DType, "d_swiglu", B, T, H);
+    Tensor d_swiglu = Tensor{Config.DType, {B, T, H}, nullptr, nullptr, 3, d_lnf.Device};
     QuantizableTensor d_mlp_up{};   // this will be handled in-place
     Tensor d_ln2 = Options.KeepAllActivations ? allocate(Config.DType, "d_ln2", B, T, C) : d_lnf;
     Tensor d_att_y = Options.KeepAllActivations ? allocate(Config.DType, "d_att_y", B, T, C) : d_lnf;
-    QuantizableTensor d_qkv{allocate(Config.DType, "d_qkv", B, T, Config.qkv_channels())};
+    QuantizableTensor d_qkv{Tensor{Config.DType, {B, T, Config.qkv_channels()}, nullptr, nullptr, 3, d_lnf.Device}};
     Tensor d_ln1 = Options.KeepAllActivations ? allocate(Config.DType, "d_ln1", B, T, C) : d_lnf;
     QuantizableTensor d_res_att = Options.KeepAllActivations ? QuantizableTensor{allocate(Config.DType, "d_res_att", B, T, C)} : d_res_ffn;
 
@@ -177,7 +177,7 @@ std::vector<LLamaRunState::LayerGradients> RunStateBuilder::allocate_backward_bu
             if(grad_dtype != Config.DType) {
                 grads.DResFFN.Quant = allocate(grad_dtype, "d_res_ffn.q", B, T, C);
                 grads.DResAtt.Quant = Options.KeepAllActivations ? allocate(grad_dtype, "d_res_att.q", B, T, C) : grads.DResFFN.Quant;
-                grads.DMlpUp.Quant = allocate(grad_dtype, "d_mlp_up.q", B, T, 2 * Config.IntermediateSize);
+                grads.DMlpUp.Quant = {grad_dtype, {B, T, 2 * Config.IntermediateSize}, nullptr, nullptr, 3, d_lnf.Device};
                 grads.DQKV.Quant = allocate(grad_dtype, "d_qkv.q", Config.qkv_channels(), B, T);
             }
             LGrads.push_back(grads);
@@ -378,8 +378,9 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     // create a dummy stack and simulate the way we're going to use temporaries later, to determine how much we need to allocate
     DeviceMemoryStack activation_stack(nullptr, 1024*1024*1024*1024ll, Inputs.Device);
 
+    bool use_fp8 = Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2;
     auto bw_qmm = [&](int B, int T, int C, int OC) {
-        if(Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2) {
+        if(use_fp8) {
             auto wgt_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, OC});
             activation_stack.free(wgt_tp.Data);
             auto act_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, B * T});
@@ -390,9 +391,19 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     };
 
     // simulate to determine required stack size
-    activation_stack.free(activation_stack.allocate(CuDNNWorkspace.bytes()));   // attention
+    auto ws = activation_stack.allocate(CuDNNWorkspace.bytes());
+    activation_stack.free(activation_stack.allocate(DActs[0].DQKV.Value.bytes()));   // attention
+    activation_stack.free(ws);   // attention
+
+    auto dswi = activation_stack.allocate(DActs[0].DSwiGLU.bytes());
     bw_qmm(B, T, H, C);         // backward qmm swiglu
-    bw_qmm(B, T, C, 2 * H);     // backward qmm up
+    activation_stack.free(dswi);
+
+    if(use_fp8) {
+        auto dupq = activation_stack.allocate(DActs[0].DMlpUp.Quant->bytes());
+        bw_qmm(B, T, C, 2 * H);     // backward qmm up
+        activation_stack.free(dupq);
+    }
     activation_stack.free(activation_stack.allocate(Output.bytes()));  // lm-head
 
     long required_size = activation_stack.max_utilization();

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -391,6 +391,22 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long 
     return state;
 }
 
+Tensor LLamaRunState::temp_alloc(ETensorDType dtype, const std::vector<long>& shape) {
+    return mTempStack.allocate(dtype, shape);
+}
+
+void LLamaRunState::temp_acquire(Tensor& target) {
+    if(target.Device != mTempStack.device_id()) {
+        throw std::logic_error("device mismatch");
+    }
+
+    target.Data = mTempStack.allocate(target.bytes());
+}
+
+void LLamaRunState::temp_free(Tensor& tensor) {
+    mTempStack.free(tensor);
+}
+
 float get_loss(LLamaRunState& acts) {
     CUDA_CHECK(cudaEventSynchronize(acts.BackwardDone));
     return acts.LossHost[0];
@@ -408,3 +424,4 @@ Tensor& get_input_buffer(LLamaRunState& acts) {
 Tensor& get_target_buffer(LLamaRunState& acts) {
     return acts.Targets_CPU;
 }
+

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -282,15 +282,14 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     long rms_scratch_size = get_rmsnorm_backward_scratch_size(C, DeviceProp);
     long bias_scratch_size = get_bias_backward_scratch_size(config.DType, config.qkv_channels(), DeviceProp);
     CudnnHandle = create_cudnn_handle();
+    long cudnn_ws_size = cudnn_get_workspace_size(B, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
 
     // batch size for chunked attention backward
     long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
-    long ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
-    ws_size = std::max(ws_size, 32l * 1024 * 1024); // Hardcoding workspace to 32MiB but only Hopper needs 32 (for others 4 is OK)
     CublasLtHandle = create_cublaslt_handle();
     RMSNormScratch = alloc->allocate(ETensorDType::BYTE, "rms_scratch", {rms_scratch_size});
     MatmulBiasScratch = alloc->allocate(ETensorDType::FP32, "bias_scratch", {bias_scratch_size / (long)sizeof(float)});
-    Workspace = alloc->allocate(ETensorDType::BYTE, "workspace", {ws_size});
+    CuBlasWorkspace = alloc->allocate(ETensorDType::BYTE, "cublas_ws", {32*1024*1024});
     DEmb = alloc->allocate(config.DType, "d_emb", {B, T, C});
 
     Acts = builder.allocate_forward_buffers(LNF);
@@ -391,6 +390,12 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     };
 
     // simulate to determine required stack size
+    // attention
+    {
+        auto ws = activation_stack.allocate(ETensorDType::BYTE, {cudnn_ws_size});
+        activation_stack.free(ws.Data);
+    }
+    CuDNNWorkspace = Tensor{ETensorDType::BYTE, {cudnn_ws_size}, nullptr, nullptr, 1, Inputs.Device};
     bw_qmm(B, T, H, C);         // backward qmm swiglu
     bw_qmm(B, T, C, 2 * H);     // backward qmm up
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -282,14 +282,14 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     long rms_scratch_size = get_rmsnorm_backward_scratch_size(C, DeviceProp);
     long bias_scratch_size = get_bias_backward_scratch_size(config.DType, config.qkv_channels(), DeviceProp);
     CudnnHandle = create_cudnn_handle();
-    long cudnn_ws_size = cudnn_get_workspace_size(B, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
-
-    // batch size for chunked attention backward
-    long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
     CublasLtHandle = create_cublaslt_handle();
     RMSNormScratch = alloc->allocate(ETensorDType::BYTE, "rms_scratch", {rms_scratch_size});
     MatmulBiasScratch = alloc->allocate(ETensorDType::FP32, "bias_scratch", {bias_scratch_size / (long)sizeof(float)});
     CuBlasWorkspace = alloc->allocate(ETensorDType::BYTE, "cublas_ws", {32*1024*1024});
+    // batch size for chunked attention backward
+    long chunk_batch_size = div_exact(B, (long)Options.AttBwdChunks);
+    long cudnn_ws_size = cudnn_get_workspace_size(chunk_batch_size, T, config.NumQueryHeads, config.NumKeyValHeads, config.head_size(), CudnnHandle);
+    CuDNNWorkspace = Tensor{ETensorDType::BYTE, {cudnn_ws_size}, nullptr, nullptr, 1, Inputs.Device};
     DEmb = alloc->allocate(config.DType, "d_emb", {B, T, C});
 
     Acts = builder.allocate_forward_buffers(LNF);
@@ -390,12 +390,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     };
 
     // simulate to determine required stack size
-    // attention
-    {
-        auto ws = activation_stack.allocate(ETensorDType::BYTE, {cudnn_ws_size});
-        activation_stack.free(ws.Data);
-    }
-    CuDNNWorkspace = Tensor{ETensorDType::BYTE, {cudnn_ws_size}, nullptr, nullptr, 1, Inputs.Device};
+    activation_stack.free(activation_stack.allocate(CuDNNWorkspace.bytes()));   // attention
     bw_qmm(B, T, H, C);         // backward qmm swiglu
     bw_qmm(B, T, C, 2 * H);     // backward qmm up
 

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -100,7 +100,8 @@ struct LLamaRunState {
     // scratch buffers
     Tensor RMSNormScratch;      // (#Blocks*C+128)
     Tensor MatmulBiasScratch;   // TODO
-    Tensor Workspace;           // shared workspace for cudnn and cublas
+    Tensor CuBlasWorkspace;
+    Tensor CuDNNWorkspace;
     Tensor EncoderBwdScratch;   // (B, T, 5 * C / (x128::size * 32))
     Tensor EncoderBwdIndices;   // (B, T, 1 * C / (x128::size * 32)) [on CPU!]
     Tensor EncoderBwdInfo;      // (B, T, 4 * C / (x128::size * 32)) [on CPU!]

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -56,6 +56,9 @@ struct LLamaRunState {
     using LayerActivations = ::sLLamaLayerActivations;
     using LayerGradients = ::sLLamaLayerGradients;
 
+    LLamaOptions Options;
+    std::shared_ptr<TensorAllocator> Allocator;
+
     Tensor Inputs;          // (B, T) Int32
     Tensor Targets;         // (B, T) Int32
     Tensor Inputs_CPU;      // (B, T) Int32
@@ -113,9 +116,6 @@ struct LLamaRunState {
     float* NormHost;
     float* LossHost;
 
-    LLamaOptions Options;
-    std::shared_ptr<TensorAllocator> Allocator;
-
     // cached GPU info
     cudaDeviceProp DeviceProp;
 
@@ -138,7 +138,7 @@ struct LLamaRunState {
     cudnnHandle_t CudnnHandle;
     cublasLtHandle_t CublasLtHandle;
 
-    void init(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);
+    void init(LLamaConfig config, long B, long T);
 };
 
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -8,6 +8,7 @@
 #include "llama_model.h"
 #include "llama_weights.h"
 #include "utilities/tensor.h"
+#include "utilities/stack.h"
 
 class TensorAllocator;
 using sLLamaGradients = sLLamaWeightsSet<TensorShard>;
@@ -115,6 +116,13 @@ struct LLamaRunState {
     Tensor NormBuffer;
     float* NormHost;
     float* LossHost;
+
+    // temporary buffers
+    Tensor temp_alloc(ETensorDType dtype, const std::vector<long>& shape);
+    void temp_acquire(Tensor& target);
+    void temp_free(Tensor& tensor);
+
+    DeviceMemoryStack mTempStack;
 
     // cached GPU info
     cudaDeviceProp DeviceProp;

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -53,7 +53,6 @@ struct sLLamaLayerGradients {
 };
 
 struct LLamaRunState {
-    using QTensor = QuantizableTensor;
     using LayerActivations = ::sLLamaLayerActivations;
     using LayerGradients = ::sLLamaLayerGradients;
 
@@ -132,12 +131,14 @@ struct LLamaRunState {
     cudaEvent_t OptimizerDone;      //!< recorded after the optimizer completes
     cudaEvent_t ResidualsAreReady;  //!< recorded after the residuals have been calculated in forward, indicating that they may be offloaded
 
-    cudaGraphExec_t GlobalNormGraph;
-    cudaGraphExec_t ForwardBlockGraph;
-    cudaGraphExec_t BackwardBlockGraph;
+    cudaGraphExec_t GlobalNormGraph = nullptr;
+    cudaGraphExec_t ForwardBlockGraph = nullptr;
+    cudaGraphExec_t BackwardBlockGraph = nullptr;
 
     cudnnHandle_t CudnnHandle;
     cublasLtHandle_t CublasLtHandle;
+
+    void init(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);
 };
 
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -105,10 +105,6 @@ struct LLamaRunState {
     Tensor EncoderBwdIndices;   // (B, T, 1 * C / (x128::size * 32)) [on CPU!]
     Tensor EncoderBwdInfo;      // (B, T, 4 * C / (x128::size * 32)) [on CPU!]
 
-    Tensor WeightTranspose;
-    Tensor ActivationTranspose;
-    Tensor GradientTranspose;
-
     std::optional<Tensor> AbsMaxes; // (L, ...)
     Tensor MatmulScales;        // 2 floats
 

--- a/src/utilities/stack.cpp
+++ b/src/utilities/stack.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2025, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "stack.h"
+#include "utilities/utils.h"
+
+DeviceMemoryStack::DeviceMemoryStack(std::byte* memory, std::size_t amount, int device_id) :
+    mBackingMemory(memory), mTop(memory), mDeviceID(device_id), mCapacity(amount) {
+
+}
+
+std::byte* DeviceMemoryStack::allocate(std::size_t amount) {
+    constexpr size_t alignment = 4096;
+    std::size_t aligned_amount = div_ceil(amount, alignment) * alignment;
+    std::byte* new_top = mTop + aligned_amount;
+    if(new_top > mBackingMemory + mCapacity) {
+        throw std::bad_alloc();
+    }
+
+    mAlloc.emplace_back(mTop, aligned_amount);
+    mTop = new_top;
+    mMaxUtilization = std::max(mMaxUtilization, mCapacity - unused_capacity());
+    return mAlloc.back().first;
+}
+
+Tensor DeviceMemoryStack::allocate(ETensorDType dtype, const std::vector<long>& shape) {
+    std::size_t total = std::accumulate(std::begin(shape), std::end(shape), (long)get_dtype_size(dtype), std::multiplies<>());
+    return Tensor::from_pointer(allocate(total), mDeviceID, dtype, shape);
+}
+
+void DeviceMemoryStack::free(std::byte* ptr) {
+    if(mAlloc.empty()) {
+        throw std::logic_error("DeviceMemoryStack::free_left called with empty allocation list");
+    }
+    if(mAlloc.back().first != ptr) {
+        throw std::logic_error("DeviceMemoryStack::free_left called with wrong pointer");
+    }
+    mTop = mAlloc.back().first;
+    mAlloc.pop_back();
+}
+
+std::size_t DeviceMemoryStack::unused_capacity() const {
+    return mCapacity - (mTop - mBackingMemory);
+}
+
+std::size_t DeviceMemoryStack::max_utilization() const {
+    return mMaxUtilization;
+}
+
+void DeviceMemoryStack::free(Tensor& tensor) {
+    free(tensor.Data);
+    tensor.Data = nullptr;
+}
+
+int DeviceMemoryStack::device_id() const {
+    return mDeviceID;
+}

--- a/src/utilities/stack.h
+++ b/src/utilities/stack.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef LLMQ_SRC_UTILITIES_STACK_H
+#define LLMQ_SRC_UTILITIES_STACK_H
+
+#include <cstddef>
+#include <vector>
+#include "utilities/tensor.h"
+
+class DeviceMemoryStack {
+public:
+    DeviceMemoryStack() = default;
+    DeviceMemoryStack(std::byte* memory, std::size_t amount, int device_id);
+
+    std::byte* allocate(std::size_t amount);
+    Tensor allocate(ETensorDType dtype, const std::vector<long>& shape);
+
+    void free(std::byte* ptr);
+    void free(Tensor& tensor);
+
+    std::size_t unused_capacity() const;
+    std::size_t max_utilization() const;
+    int device_id() const;
+private:
+    int mDeviceID;
+    std::byte* mBackingMemory;
+    std::byte* mTop;
+    std::size_t mCapacity;
+
+    using AllocationList = std::vector<std::pair<std::byte*, std::size_t>>;
+    AllocationList mAlloc;
+
+    std::size_t mMaxUtilization = 0;
+};
+
+#endif //LLMQ_SRC_UTILITIES_STACK_H

--- a/src/utilities/tensor.h
+++ b/src/utilities/tensor.h
@@ -64,6 +64,23 @@ struct Tensor {
 
         return reinterpret_cast<TargetType*>(Data);
     }
+
+
+    template<typename Container>
+    static Tensor from_pointer(std::byte* ptr, int device, ETensorDType dtype, const Container& shape)
+    {
+        if(shape.size() > MAX_TENSOR_DIM) {
+            throw std::runtime_error("Tensor rank too large");
+        }
+
+        int rank = narrow<int>(shape.size());
+        std::array<long, MAX_TENSOR_DIM> sizes{};
+        std::copy(shape.begin(), shape.end(), sizes.begin());
+        std::fill(sizes.begin() + shape.size(), sizes.end(), 1);
+
+        return Tensor{dtype, sizes, ptr, nullptr, rank, device};
+    }
+
 };
 
 void fill_zero(Tensor& dst, cudaStream_t stream);


### PR DESCRIPTION
Implements stack-based management for several temporary allocations. This gives us a more principled way of sharing memory for different tensors, especially if those tensors are not of the same shape or dtype.