### PR TITLE
Rope absmax fusion

### DIFF
--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -71,21 +71,21 @@ void swiglu_backward(Tensor& dinp, const Tensor& dout, const Tensor& inp, float*
     }
 }
 
-void rope_forward(Tensor& out, const Tensor& in, const Tensor& freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
+void rope_forward(Tensor& out, const Tensor& in, const Tensor& freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
     if(out.DType == ETensorDType::FP32) {
-        rope_forward(out.get<float>(), in.get<float>(), freqs_cis.get<float>(), B, T, Nq, Nkv, head_dim, stream);
+        rope_forward(out.get<float>(), in.get<float>(), freqs_cis.get<float>(), abs_max_ptr, B, T, Nq, Nkv, head_dim, stream);
     } else if(out.DType == ETensorDType::BF16) {
-        rope_forward(out.get<nv_bfloat16>(), in.get<nv_bfloat16>(), freqs_cis.get<nv_bfloat16>(), B, T, Nq, Nkv, head_dim, stream);
+        rope_forward(out.get<nv_bfloat16>(), in.get<nv_bfloat16>(), freqs_cis.get<nv_bfloat16>(), abs_max_ptr, B, T, Nq, Nkv, head_dim, stream);
     } else {
         throw std::logic_error("rope_forward: unsupported dtype");
     }
 }
 
-void rope_backward(Tensor& dinp, const Tensor& dout, const Tensor& freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
+void rope_backward(Tensor& dinp, const Tensor& dout, const Tensor& freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
     if(dinp.DType == ETensorDType::FP32) {
-        rope_backward(dinp.get<float>(), dout.get<float>(), freqs_cis.get<float>(), B, T, Nq, Nkv, head_dim, stream);
+        rope_backward(dinp.get<float>(), dout.get<float>(), freqs_cis.get<float>(), abs_max_ptr, B, T, Nq, Nkv, head_dim, stream);
     } else if(dinp.DType == ETensorDType::BF16) {
-        rope_backward(dinp.get<nv_bfloat16>(), dout.get<nv_bfloat16>(), freqs_cis.get<nv_bfloat16>(), B, T, Nq, Nkv, head_dim, stream);
+        rope_backward(dinp.get<nv_bfloat16>(), dout.get<nv_bfloat16>(), freqs_cis.get<nv_bfloat16>(), abs_max_ptr, B, T, Nq, Nkv, head_dim, stream);
     } else {
         throw std::logic_error("rope_backward: unsupported dtype");
     }

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -105,12 +105,12 @@ void backward_bias(Tensor& dbias, const Tensor& dout, const float* dout_abs_max,
 
 void precompute_freqs_cis(float *freqs_cis, int dim, int end, float theta);
 void precompute_freqs_cis(nv_bfloat16 *freqs_cis, int dim, int end, float theta);
-void rope_forward(float* out, const float* in, const float *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
-void rope_forward(nv_bfloat16* out, const nv_bfloat16* in, const nv_bfloat16 *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
-void rope_forward(Tensor& out, const Tensor& in, const Tensor& freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
-void rope_backward(float* dinp, const float* dout, const float *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
-void rope_backward(nv_bfloat16* dinp, const nv_bfloat16* dout, const nv_bfloat16 *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
-void rope_backward(Tensor& dinp, const Tensor& dout, const Tensor& freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_forward(float* out, const float* in, const float *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_forward(nv_bfloat16* out, const nv_bfloat16* in, const nv_bfloat16 *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_forward(Tensor& out, const Tensor& in, const Tensor& freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_backward(float* dinp, const float* dout, const float *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_backward(nv_bfloat16* dinp, const nv_bfloat16* dout, const nv_bfloat16 *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
+void rope_backward(Tensor& dinp, const Tensor& dout, const Tensor& freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream);
 
 // swiglu assumes that input is the concatenation of gate and up projection.
 void swiglu_forward(nv_bfloat16* out, const nv_bfloat16* inp, float* abs_max_ptr, int B, int T, int C, cudaStream_t stream);

--- a/src/kernels/rope.cu
+++ b/src/kernels/rope.cu
@@ -67,11 +67,14 @@ __global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_
         if(abs_max_ptr) {
             x128 val = x128::load_cs(inp + 2 * idx);
             for(int k = 0; k < x128::size; k++) {
-                thread_max = std::max(thread_max, fabsf(val[k]));
+                thread_max = fmaxf(thread_max, fabsf(val[k]));
             }
             if (out != inp) {
                 val.store(out + 2 * idx);
             }
+            // this thread is not participating in the block-level reduction, so we need to update
+            // globally before exiting
+            atomicMax(reinterpret_cast<unsigned int*>(abs_max_ptr), __float_as_uint(thread_max));
             return;
         } else {
             // if not in place, need to copy the value heads
@@ -105,8 +108,8 @@ __global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_
         o_real[k] = real * cos - imag * sin;
         o_imag[k] = real * sin + imag * cos;
         if (abs_max_ptr) {
-            thread_max = std::max(thread_max, fabsf(o_real[k]));
-            thread_max = std::max(thread_max, fabsf(o_imag[k]));
+            thread_max = fmaxf(thread_max, fabsf(o_real[k]));
+            thread_max = fmaxf(thread_max, fabsf(o_imag[k]));
         }
     }
     o_real.store(out + idxi);

--- a/src/kernels/rope.cu
+++ b/src/kernels/rope.cu
@@ -37,9 +37,17 @@ void precompute_freqs_cis(nv_bfloat16 *freqs_cis, int dim, int end, float theta)
 }
 
 template<bool Backward, typename floatX>
-__global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, std::bool_constant<Backward> bw = {}) {
+__global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_cis, float* abs_max_ptr,
+                            int B, int T, int Nq, int Nkv, int head_dim, std::bool_constant<Backward> bw = {}) {
     using x64 = GenericVector<floatX, 8/sizeof(floatX)>;
     using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
+    __shared__ float block_max;
+    if (abs_max_ptr) {
+        if(threadIdx.x == 0)
+            block_max = 1e-10f;
+        __syncthreads();
+    }
+    float thread_max = 1e-10f;
 
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x64::size;
     int head_dim_half = head_dim / 2;
@@ -54,12 +62,24 @@ __global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_
         qkv = 1;        // key head
         h -= Nq;
     }
+
     if (qkv == 2) {
-        // if not in place, need to copy the value heads
-        if(out != inp) {
-            x128::load_cs(inp + 2*idx).store(out + 2*idx);
+        if(abs_max_ptr) {
+            x128 val = x128::load_cs(inp + 2 * idx);
+            for(int k = 0; k < x128::size; k++) {
+                thread_max = std::max(thread_max, fabsf(val[k]));
+            }
+            if (out != inp) {
+                val.store(out + 2 * idx);
+            }
+            return;
+        } else {
+            // if not in place, need to copy the value heads
+            if (out != inp) {
+                x128::load_cs(inp + 2 * idx).store(out + 2 * idx);
+            }
+            return;
         }
-        return;
     }
     // decode the individual indices and get the input index
     int b = idx / (T * N * head_dim_half);
@@ -84,35 +104,50 @@ __global__ void rope_kernel(floatX *out, const floatX *inp, const floatX *freqs_
         float imag = (float)v_imag[k];
         o_real[k] = real * cos - imag * sin;
         o_imag[k] = real * sin + imag * cos;
+        if (abs_max_ptr) {
+            thread_max = std::max(thread_max, fabsf(o_real[k]));
+            thread_max = std::max(thread_max, fabsf(o_imag[k]));
+        }
     }
     o_real.store(out + idxi);
     o_imag.store(out + idxi + head_dim_half);
+
+    if (abs_max_ptr) {
+        atomicMax_block(reinterpret_cast<unsigned int*>(&block_max), __float_as_uint(thread_max));
+        __syncthreads();
+        if(threadIdx.x == 0) {
+            atomicMax(reinterpret_cast<unsigned int*>(abs_max_ptr), __float_as_uint(block_max));
+        }
+    }
 }
 
 template<bool Backward, class floatX>
-void rope_imp(floatX* out, const floatX* in, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream, std::bool_constant<Backward> bw = {}) {
+void rope_imp(floatX* out, const floatX* in, const floatX *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream, std::bool_constant<Backward> bw = {}) {
     // the input and output to this kernel are (B, T, Nq + Nk + Nv, HD)
+    if (abs_max_ptr)
+        CUDA_CHECK(cudaMemsetAsync(abs_max_ptr, 0, sizeof(float), stream));
+
     const int block_size = 128;
     using x64 = GenericVector<floatX, 8/sizeof(floatX)>;
     assert(head_dim % (2*x64::size) == 0);
     int total_threads = (B * T * (Nq + 2*Nkv) * head_dim / 2) / x64::size;
     int num_blocks = div_ceil(total_threads, block_size);
-    rope_kernel<<<num_blocks, block_size, 0, stream>>>(out, in, freqs_cis, B, T, Nq, Nkv, head_dim, bw);
+    rope_kernel<<<num_blocks, block_size, 0, stream>>>(out, in, freqs_cis, abs_max_ptr, B, T, Nq, Nkv, head_dim, bw);
     CUDA_CHECK(cudaGetLastError());
 }
 
-void rope_forward(float* out, const float* in, const float *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
-    rope_imp(out, in, freqs_cis, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<false>());
+void rope_forward(float* out, const float* in, const float *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
+    rope_imp(out, in, freqs_cis, abs_max_ptr, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<false>());
 }
 
-void rope_forward(nv_bfloat16* out, const nv_bfloat16* in, const nv_bfloat16 *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
-    rope_imp(out, in, freqs_cis, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<false>());
+void rope_forward(nv_bfloat16* out, const nv_bfloat16* in, const nv_bfloat16 *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
+    rope_imp(out, in, freqs_cis,  abs_max_ptr, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<false>());
 }
 
-void rope_backward(float* dinp, const float* dout, const float *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
-    rope_imp(dinp, dout, freqs_cis, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<true>());
+void rope_backward(float* dinp, const float* dout, const float *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
+    rope_imp(dinp, dout, freqs_cis, abs_max_ptr, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<true>());
 }
 
-void rope_backward(nv_bfloat16* dinp, const nv_bfloat16* dout, const nv_bfloat16 *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
-    rope_imp(dinp, dout, freqs_cis, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<true>());
+void rope_backward(nv_bfloat16* dinp, const nv_bfloat16* dout, const nv_bfloat16 *freqs_cis, float* abs_max_ptr, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream)  {
+    rope_imp(dinp, dout, freqs_cis, abs_max_ptr, B, T, Nq, Nkv, head_dim, stream, std::bool_constant<true>());
 }

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -189,7 +189,7 @@ void LLamaModel::_forward_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLayer
                 B, T, C, Config.qkv_channels(),
                 rs->DeviceProp, false, main_stream);
     // 2) apply RoPE to q,k (potentially in place)
-    rope_forward(acts.QKV, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
+    rope_forward(acts.QKV, acts.QKV, rs->FreqCis, nullptr, B, T, Hq, Hkv, Hs, main_stream);
     // 3) attention: att <- softmax(qk^T)v
     attention_forward_cudnn(acts.Att.Value, acts.LSE, acts.QKV, rs->CuBlasWorkspace, rs->CudnnHandle, B, T, Hq, Hkv, Hs, main_stream);
     // quantize attention if necessary
@@ -542,7 +542,7 @@ void LLamaModel::_recompute_block(sLLamaBlockWeights<Tensor>& weights, sLLamaLay
                      rs->CublasLtHandle, rs->CuBlasWorkspace,
                      B, T, C, Config.qkv_channels(),
                      rs->DeviceProp, !recompute_ln1, main_stream);
-        rope_forward(acts.QKV, acts.QKV, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
+        rope_forward(acts.QKV, acts.QKV, rs->FreqCis, nullptr, B, T, Hq, Hkv, Hs, main_stream);
     }
 
     if (recompute_att) {
@@ -636,11 +636,7 @@ void LLamaModel::_backward_block(bool accumulate, sLLamaBlockWeights<Tensor>& we
             chunk_batch_size, T, Hq, Hkv, Hs, main_stream);
     }
     rs->temp_free(rs->CuDNNWorkspace);
-    rope_backward(d_acts.DQKV.Value, d_acts.DQKV.Value, rs->FreqCis, B, T, Hq, Hkv, Hs, main_stream);
-
-    if (d_acts.DQKV.Quant.has_value()) {
-        abs_max(d_acts.DQKV.Quant->Scales, d_acts.DQKV.Value, d_acts.DQKV.Value.nelem(), rs->DeviceProp, main_stream);
-    }
+    rope_backward(d_acts.DQKV.Value, d_acts.DQKV.Value, rs->FreqCis, quant_abs_max_ptr(d_acts.DQKV), B, T, Hq, Hkv, Hs, main_stream);
 
     backward_qmm(d_acts.DLN1, d_weights.Attn_QKV_w, d_weights.Attn_QKV_b, d_acts.DQKV, acts.LN1, weights.Attn_QKV_w, rs->MatmulBiasScratch,
                  accumulate, *rs, B, T, C, Config.qkv_channels(), !recompute_ln1, main_stream);

--- a/src/testing/test-rope.cu
+++ b/src/testing/test-rope.cu
@@ -129,6 +129,22 @@ TEST_CASE("rope forward/backward fp32 matches CPU", "[rope][fp32]") {
         REQUIRE(h_out[i] == Catch::Approx(h_out_cpu[i]).margin(1e-6f));
     }
 
+    // Forward again with absmax and ensure bit-perfect identical results, and absmax matches expected
+    thrust::device_vector<float> d_absmax_fwd(1);
+    thrust::device_vector<float> d_out2(size_inp);
+    rope_forward(thrust::raw_pointer_cast(d_out2.data()),
+                 thrust::raw_pointer_cast(d_inp.data()),
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 thrust::raw_pointer_cast(d_absmax_fwd.data()), B, T, Nq, Nkv, HD, 0);
+    std::vector<float> h_out2 = from_device(d_out2);
+    for (size_t i = 0; i < size_inp; ++i) {
+        REQUIRE(h_out2[i] == h_out[i]); // bit-perfect identical
+    }
+    float h_absmax_fwd = from_device(d_absmax_fwd)[0];
+    float expected_absmax_fwd = 0.0f;
+    for (size_t i = 0; i < size_inp; ++i) expected_absmax_fwd = std::max(expected_absmax_fwd, std::fabs(h_out_cpu[i]));
+    REQUIRE(h_absmax_fwd == Catch::Approx(expected_absmax_fwd).margin(1e-6f));
+
     // Backward: generate dout and compare dinp
     std::vector<float> h_dout = uniform_host(size_inp,  -0.5, 0.5, 424242ull);
     std::vector<float> h_dinp_cpu(size_inp);
@@ -147,6 +163,23 @@ TEST_CASE("rope forward/backward fp32 matches CPU", "[rope][fp32]") {
     for (size_t i = 0; i < size_inp; ++i) {
         REQUIRE(h_dinp[i] == Catch::Approx(h_dinp_cpu[i]).margin(1e-6f));
     }
+
+    // Backward again with absmax and ensure bit-perfect identical results, and absmax matches expected
+    thrust::device_vector<float> d_absmax_bwd(1);
+    thrust::device_vector<float> d_dinp2(size_inp);
+    rope_backward(thrust::raw_pointer_cast(d_dinp2.data()),
+                  thrust::raw_pointer_cast(d_dout.data()),
+                  thrust::raw_pointer_cast(d_freqs.data()),
+                  thrust::raw_pointer_cast(d_absmax_bwd.data()),
+                  B, T, Nq, Nkv, HD, 0);
+    std::vector<float> h_dinp2 = from_device(d_dinp2);
+    for (size_t i = 0; i < size_inp; ++i) {
+        REQUIRE(h_dinp2[i] == h_dinp[i]); // bit-perfect identical
+    }
+    float h_absmax_bwd = from_device(d_absmax_bwd)[0];
+    float expected_absmax_bwd = 0.0f;
+    for (size_t i = 0; i < size_inp; ++i) expected_absmax_bwd = std::max(expected_absmax_bwd, std::fabs(h_dinp_cpu[i]));
+    REQUIRE(h_absmax_bwd == Catch::Approx(expected_absmax_bwd).margin(1e-6f));
 }
 
 TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]") {
@@ -204,6 +237,25 @@ TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]
         REQUIRE(v == Catch::Approx(h_out_cpu[i]).margin(3e-2f));
     }
 
+    // Forward again with absmax, ensure bit-perfect identical bf16 outputs, check absmax
+    std::vector<nv_bfloat16> h_out_bf16_ref = h_out_bf16; // keep reference for bitwise compare
+    thrust::device_vector<float> d_absmax_fwd_bf16(1);
+    rope_forward(thrust::raw_pointer_cast(d_out.data()),
+                 thrust::raw_pointer_cast(d_inp.data()),
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 thrust::raw_pointer_cast(d_absmax_fwd_bf16.data()), B, T, Nq, Nkv, HD, 0);
+    h_out_bf16 = from_device(d_out);
+    for (size_t i = 0; i < size_inp; ++i) {
+        uint16_t a, b;
+        std::memcpy(&a, &h_out_bf16[i], sizeof(a));
+        std::memcpy(&b, &h_out_bf16_ref[i], sizeof(b));
+        REQUIRE(a == b); // bit-perfect identical
+    }
+    float h_absmax_fwd_bf16 = from_device(d_absmax_fwd_bf16)[0];
+    float expected_absmax_fwd_bf16 = 0.0f;
+    for (size_t i = 0; i < size_inp; ++i) expected_absmax_fwd_bf16 = std::max(expected_absmax_fwd_bf16, std::fabs(h_out_cpu[i]));
+    REQUIRE(h_absmax_fwd_bf16 == Catch::Approx(expected_absmax_fwd_bf16).margin(3e-2f));
+
     // Backward bf16
     std::vector<float> h_dout_f = uniform_host(size_inp, -0.5f, 0.5f, 424242ull);
     std::vector<nv_bfloat16> h_dout_bf16 = to_bf16(h_dout_f);
@@ -226,4 +278,23 @@ TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]
         float v = bf16_bits_to_float(bits);
         REQUIRE(v == Catch::Approx(h_dinp_cpu[i]).margin(3e-2f));
     }
+
+    // Backward again with absmax, bitwise identity and absmax check
+    std::vector<nv_bfloat16> h_dinp_bf16_ref = h_dinp_bf16;
+    thrust::device_vector<float> d_absmax_bwd_bf16(1);
+    rope_backward(thrust::raw_pointer_cast(d_dinp.data()),
+                  thrust::raw_pointer_cast(d_dout.data()),
+                  thrust::raw_pointer_cast(d_freqs.data()),
+                  thrust::raw_pointer_cast(d_absmax_bwd_bf16.data()), B, T, Nq, Nkv, HD, 0);
+    h_dinp_bf16 = from_device(d_dinp);
+    for (size_t i = 0; i < size_inp; ++i) {
+        uint16_t a, b;
+        std::memcpy(&a, &h_dinp_bf16[i], sizeof(a));
+        std::memcpy(&b, &h_dinp_bf16_ref[i], sizeof(b));
+        REQUIRE(a == b);
+    }
+    float h_absmax_bwd_bf16 = from_device(d_absmax_bwd_bf16)[0];
+    float expected_absmax_bwd_bf16 = 0.0f;
+    for (size_t i = 0; i < size_inp; ++i) expected_absmax_bwd_bf16 = std::max(expected_absmax_bwd_bf16, std::fabs(h_dinp_cpu[i]));
+    REQUIRE(h_absmax_bwd_bf16 == Catch::Approx(expected_absmax_bwd_bf16).margin(3e-2f));
 }

--- a/src/testing/test-rope.cu
+++ b/src/testing/test-rope.cu
@@ -120,7 +120,8 @@ TEST_CASE("rope forward/backward fp32 matches CPU", "[rope][fp32]") {
 
     rope_forward(thrust::raw_pointer_cast(d_out.data()),
                  thrust::raw_pointer_cast(d_inp.data()),
-                 thrust::raw_pointer_cast(d_freqs.data()), B, T, Nq, Nkv, HD, 0);
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 nullptr, B, T, Nq, Nkv, HD, 0);
 
     std::vector<float> h_out(size_inp);
     thrust::copy(d_out.begin(), d_out.end(), h_out.begin());
@@ -138,7 +139,9 @@ TEST_CASE("rope forward/backward fp32 matches CPU", "[rope][fp32]") {
 
     rope_backward(thrust::raw_pointer_cast(d_dinp.data()),
                   thrust::raw_pointer_cast(d_dout.data()),
-                  thrust::raw_pointer_cast(d_freqs.data()), B, T, Nq, Nkv, HD, 0);
+                  thrust::raw_pointer_cast(d_freqs.data()),
+                  nullptr,
+                  B, T, Nq, Nkv, HD, 0);
 
     std::vector<float> h_dinp = from_device(d_dinp);
     for (size_t i = 0; i < size_inp; ++i) {
@@ -190,7 +193,8 @@ TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]
 
     rope_forward(thrust::raw_pointer_cast(d_out.data()),
                  thrust::raw_pointer_cast(d_inp.data()),
-                 thrust::raw_pointer_cast(d_freqs.data()), B, T, Nq, Nkv, HD, 0);
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 nullptr, B, T, Nq, Nkv, HD, 0);
 
     std::vector<nv_bfloat16> h_out_bf16 = from_device(d_out);
     for (size_t i = 0; i < size_inp; ++i) {
@@ -212,7 +216,8 @@ TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]
 
     rope_backward(thrust::raw_pointer_cast(d_dinp.data()),
                   thrust::raw_pointer_cast(d_dout.data()),
-                  thrust::raw_pointer_cast(d_freqs.data()), B, T, Nq, Nkv, HD, 0);
+                  thrust::raw_pointer_cast(d_freqs.data()),
+                  nullptr, B, T, Nq, Nkv, HD, 0);
 
     std::vector<nv_bfloat16> h_dinp_bf16 = from_device(d_dinp);
     for (size_t i = 0; i < size_inp; ++i) {

--- a/src/testing/test-rope.cu
+++ b/src/testing/test-rope.cu
@@ -298,3 +298,60 @@ TEST_CASE("rope forward/backward bfloat16 matches CPU (emulated)", "[rope][bf16]
     for (size_t i = 0; i < size_inp; ++i) expected_absmax_bwd_bf16 = std::max(expected_absmax_bwd_bf16, std::fabs(h_dinp_cpu[i]));
     REQUIRE(h_absmax_bwd_bf16 == Catch::Approx(expected_absmax_bwd_bf16).margin(3e-2f));
 }
+
+// New tests to ensure abs-max path participates for values and to catch sync/early-return bugs
+TEST_CASE("rope absmax (fp32)", "[rope][fp32][absmax]") {
+    using namespace testing_config;
+    // Craft sizes to force blocks to span Q/K and V regions in the same block
+    // Small problem so a single block likely processes mixed heads
+    const int B = 1, T = 64, Nq = 2, Nkv = 2, HD = 32;
+    const int N = Nq + 2 * Nkv;
+
+    const size_t size_inp = (size_t)B * T * N * HD;
+    const size_t size_freqs = (size_t)T * HD;
+
+    // Random input, large outlier in V region
+    std::vector<float> h_inp = uniform_host(size_inp, -0.9f, 0.9f, 2025ull);
+    h_inp[129] = 10.f;
+    std::vector<float> h_freqs(size_freqs);
+    precompute_freqs_cis(h_freqs.data(), HD, T, 10000.0f);
+
+    // CPU reference
+    std::vector<float> h_out_cpu(size_inp);
+    rope_forward_cpu(h_out_cpu.data(), h_inp.data(), h_freqs.data(), B, T, Nq, Nkv, HD);
+
+    // Device buffers
+    thrust::device_vector<float> d_inp = to_device(h_inp);
+    thrust::device_vector<float> d_out(size_inp);
+    thrust::device_vector<float> d_freqs = to_device(h_freqs);
+
+    // Out-of-place with absmax
+    thrust::device_vector<float> d_absmax(1);
+    rope_forward(thrust::raw_pointer_cast(d_out.data()),
+                 thrust::raw_pointer_cast(d_inp.data()),
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 thrust::raw_pointer_cast(d_absmax.data()),
+                 B, T, Nq, Nkv, HD, 0);
+
+    std::vector<float> h_out = from_device(d_out);
+    for (size_t i = 0; i < size_inp; ++i) {
+        REQUIRE(h_out[i] == Catch::Approx(h_out_cpu[i]).margin(1e-6f));
+    }
+    float absmax = from_device(d_absmax)[0];
+    float expected_abs = 10.f;
+    REQUIRE(absmax == Catch::Approx(expected_abs).margin(1e-6f)); // must include V region too
+
+    // In-place with absmax should produce identical results
+    thrust::device_vector<float> d_absmax_ip(1);
+    // Copy input to output buffer to perform in-place
+    thrust::device_vector<float> d_io = d_inp; // start from input
+    rope_forward(thrust::raw_pointer_cast(d_io.data()),
+                 thrust::raw_pointer_cast(d_io.data()),
+                 thrust::raw_pointer_cast(d_freqs.data()),
+                 thrust::raw_pointer_cast(d_absmax_ip.data()),
+                 B, T, Nq, Nkv, HD, 0);
+    std::vector<float> h_io = from_device(d_io);
+    for (size_t i = 0; i < size_inp; ++i) {
+        REQUIRE(h_io[i] == Catch::Approx(h_out_cpu[i]).margin(1e-6f));
+    }
+}


### PR DESCRIPTION
Fuse abs-max and (backward) RoPE, avoiding one re-read of qkv from global memory