### PR TITLE
Add  simple gradient offloading

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -43,6 +43,7 @@ def setup_options(config: pyllmq.TrainingConfig) -> pyllmq.LLamaOptions:
     options.offload_quants = config.offload_quants
     options.offload_opt_m = config.offload_opt_m
     options.offload_opt_v = config.offload_opt_v
+    options.offload_grads = config.offload_grads
     options.persistent_quants = config.persistent_quants
 
     # Performance options

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -178,7 +178,7 @@ NB_MODULE(_pyllmq, m) {
         .def("__init__", [](LLamaOptions *t, bool recompute_swiglu, bool recompute_rmsnorm,
             bool recompute_ffn, bool recompute_qkv, bool recompute_att, bool recompute_block, bool offload_residual,
             bool use_cuda_graphs,
-            bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v, bool use_zero_copy,
+            bool offload_master, bool offload_quants, bool offload_opt_m, bool offload_opt_v, bool offload_grads, bool use_zero_copy,
             bool use_write_combined, bool shard_weights, bool persistent_quants, bool shard_gradients, bool use_all_to_all_reduce,
             bool init_projections_to_zero, int lmhead_chunks, int attn_bwd_chunks,
             const std::string matmul_type, const std::string gradient_type, const std::string master_dtype, const std::string momentum_type, const std::string variance_type) {
@@ -197,6 +197,7 @@ NB_MODULE(_pyllmq, m) {
                 .OffloadQuants = offload_quants,
                 .OffloadOptM = offload_opt_m,
                 .OffloadOptV = offload_opt_v,
+                .OffloadGrads = offload_grads,
                 .UseZeroCopy = use_zero_copy,
                 .UseWriteCombined = use_write_combined,
                 .ShardWeights = shard_weights,
@@ -217,8 +218,8 @@ NB_MODULE(_pyllmq, m) {
              nb::arg("offload_residual") = false,
              nb::arg("use_cuda_graphs") = true,   nb::arg("offload_master") = false,
              nb::arg("offload_quants") = false,   nb::arg("offload_opt_m") = false,
-             nb::arg("offload_opt_v") = false,    nb::arg("use_zero_copy") = false,
-             nb::arg("use_write_combined") = false,
+             nb::arg("offload_opt_v") = false,    nb::arg("offload_grads") = false,
+             nb::arg("use_zero_copy") = false,    nb::arg("use_write_combined") = false,
              nb::arg("shard_weights") = false,    nb::arg("persistent_quants") = false,
              nb::arg("shard_gradients") = false,  nb::arg("use_all_to_all_reduce") = false,
              nb::arg("init_projections_to_zero") = false, nb::arg("lmhead_chunks") = 1,
@@ -241,6 +242,7 @@ NB_MODULE(_pyllmq, m) {
         .def_rw("offload_quants", &LLamaOptions::OffloadQuants)
         .def_rw("offload_opt_m", &LLamaOptions::OffloadOptM)
         .def_rw("offload_opt_v", &LLamaOptions::OffloadOptV)
+        .def_rw("offload_grads", &LLamaOptions::OffloadGrads)
         .def_rw("use_zero_copy", &LLamaOptions::UseZeroCopy)
         .def_rw("use_write_combined", &LLamaOptions::UseWriteCombined)
         .def_rw("shard_weights", &LLamaOptions::ShardWeights)

--- a/src/binding/python/tests/recompute.py
+++ b/src/binding/python/tests/recompute.py
@@ -34,6 +34,7 @@ def disable_recompute(config: TrainingConfig):
     baseline_config.offload_quants = False
     baseline_config.offload_opt_v = False
     baseline_config.offload_opt_m = False
+    baseline_config.offload_grads = False
     baseline_config.attn_bwd_chunks = 1
     baseline_config.memcpy_all_gather = False
     baseline_config.shard_weights = False

--- a/src/binding/python/tests/run.py
+++ b/src/binding/python/tests/run.py
@@ -72,6 +72,7 @@ def _create_options(config: TrainingConfig) -> pyllmq.LLamaOptions:
     options.offload_opt_v = config.offload_opt_v
     options.offload_quants = config.offload_quants
     options.offload_master = config.offload_master
+    options.offload_grads = config.offload_grads
     options.persistent_quants = config.persistent_quants
 
     if config.matmul_dtype:

--- a/src/binding/python/training.py
+++ b/src/binding/python/training.py
@@ -80,6 +80,7 @@ class TrainingConfig:
     offload_quants: bool = False
     offload_opt_m: bool = False
     offload_opt_v: bool = False
+    offload_grads: bool = False
     persistent_quants: bool = False
 
     # Performance options
@@ -174,6 +175,7 @@ def add_training_args(parser: argparse.ArgumentParser, default: Optional[Trainin
     parser.add_argument("--offload-quants", action="store_true", help="Offload quantized weights")
     parser.add_argument("--offload-opt-m", action="store_true", help="Offload first-order momentum")
     parser.add_argument("--offload-opt-v", action="store_true", help="Offload second-order momentum")
+    parser.add_argument("--offload-grads", action="store_true", help="Offload gradients")
     parser.add_argument("--persistent-quants", action="store_true", help="Keep quantized weights")
     parser.add_argument("--use-zero-copy", action="store_true", help="Use zero-copy DMA for offloaded optimizer states")
 

--- a/src/models/llama_gradients.cpp
+++ b/src/models/llama_gradients.cpp
@@ -480,6 +480,9 @@ std::unique_ptr<LLamaGradsManager> LLamaGradsManager::create(std::uint64_t seed,
         }
 
     } else {
+        if(options.OffloadGrads) {
+            throw std::logic_error("Offloading gradients is not supported for unsharded gradients");
+        }
         return std::make_unique<LLamaGradientsUnsharded>(seed, step, config, rank, world, alloc);
     }
 }

--- a/src/models/llama_gradients.cpp
+++ b/src/models/llama_gradients.cpp
@@ -167,7 +167,7 @@ void LLamaGradientsUnsharded::notify_block(int layer_idx, cudaStream_t stream, N
 // shard the transformer blocks, but not the embeddings and lmhead.
 class LLamaGradientsBlockShardedBase : public LLamaGradsManager {
 public:
-    LLamaGradientsBlockShardedBase(std::uint64_t seed, int step, const LLamaConfig& config, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc);
+    LLamaGradientsBlockShardedBase(std::uint64_t seed, int step, const LLamaConfig& config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc);
 
     void on_first_micro_step(cudaStream_t stream) override;
     void end_micro_step(cudaStream_t stream, NCCLCommunicator& comm) override;
@@ -207,7 +207,7 @@ private:
     cudaEvent_t mNonBlockEvent;
 };
 
-LLamaGradientsBlockShardedBase::LLamaGradientsBlockShardedBase(std::uint64_t seed, int step, const LLamaConfig& config, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc):
+LLamaGradientsBlockShardedBase::LLamaGradientsBlockShardedBase(std::uint64_t seed, int step, const LLamaConfig& config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc):
     LLamaGradsManager(seed, step),
     mFullNonBlock( allocate_non_block_full(config, config.DType, EAllocationType::ON_DEVICE, *alloc))
 {
@@ -218,7 +218,8 @@ LLamaGradientsBlockShardedBase::LLamaGradientsBlockShardedBase(std::uint64_t see
     mNonBlockEvent = create_named_event("grad_nonblock_event");
     mGradShards.reserve(config.NumLayers);
     for(int i = 0; i < config.NumLayers; ++i) {
-        mGradShards.push_back(allocate_block_shard(config, config.DType, config.DType, EAllocationType::ON_DEVICE, rank, world, *alloc));
+        EAllocationType kind = options.OffloadGrads ? EAllocationType::PINNED : EAllocationType::ON_DEVICE;
+        mGradShards.push_back(allocate_block_shard(config, config.DType, config.DType, kind, rank, world, *alloc));
     }
 
     mNonBlockShards = shard_non_block(mFullNonBlock, rank, world);
@@ -473,9 +474,9 @@ void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_layer(int layer_idx,
 std::unique_ptr<LLamaGradsManager> LLamaGradsManager::create(std::uint64_t seed, int step, const LLamaConfig& config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc) {
     if (options.ShardGradients) {
         if(options.UseAllToAllReduce) {
-            return std::make_unique<LLamaGradientsBlockSharded_AllToAll>(seed, step, config, rank, world, alloc);
+            return std::make_unique<LLamaGradientsBlockSharded_AllToAll>(seed, step, config, options, rank, world, alloc);
         } else {
-            return std::make_unique<LLamaGradientsBlockSharded_ScatterReduce>(seed, step, config, rank, world, alloc);
+            return std::make_unique<LLamaGradientsBlockSharded_ScatterReduce>(seed, step, config, options, rank, world, alloc);
         }
 
     } else {

--- a/src/models/llama_model.h
+++ b/src/models/llama_model.h
@@ -34,6 +34,7 @@ struct LLamaOptions {
     bool OffloadQuants = false;
     bool OffloadOptM   = false;
     bool OffloadOptV   = false;
+    bool OffloadGrads  = false;
     bool UseZeroCopy   = false;
     bool UseWriteCombined = false;
     bool ShardWeights = false;

--- a/train.cpp
+++ b/train.cpp
@@ -168,6 +168,7 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_flag("--offload-quants", Options.OffloadQuants, "Store quantized weights in pinned host memory.")->needs(persist);
     app.add_flag("--offload-opt-m", Options.OffloadOptM, "Store first-order momentum in pinned host memory.");
     app.add_flag("--offload-opt-v", Options.OffloadOptV, "Store second-order momentum in pinned host memory.");
+    app.add_flag("--offload-gradients", Options.OffloadGrads, "Offload gradients to pinned host memory.");
     app.add_flag("--use-zero-copy", Options.UseZeroCopy, "Use ZeroCopy memory access, instead of double-buffered cudaMemcpy, for offloaded optimizer states. On consumer cards, DMA appears to be much slower, whereas on professional cards it is faster.");
     app.add_flag("--shard-gradients", Options.ShardGradients, "Shard gradients across GPUs")->excludes(zero);
     app.add_flag("--memcpy-all-gather", MemcpyAllGather, "Use memcpy to perform all-gathers. Currently only supported by the threads backend.");


### PR DESCRIPTION
Offload gradients by simply cudaMalloHost'ing them. Does not necessarily result in the most efficient transfers, but there are situations where the overhead is manageable and the memory benefit is huge.