### PR TITLE
Reuse buffers for offloaded optimizer double buffering

### DIFF
--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -735,7 +735,8 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         CUDA_CHECK(cudaEventRecord(rs->TimingOptimizerStart, main_stream));
     }
 
-    Parameters->begin_optimizer(rs->mTempStack, rs->MainStream);
+    Parameters->begin_optimizer(rs->Stack, rs->MainStream);
+    OptimizerState->begin_optimizer(rs->Stack);
 
     // grad_scale gets deposited into NormBuffer[1] and can be used on main_stream after this.
     calculate_gradient_norm(comm, grad_clip);
@@ -799,7 +800,8 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         comm.reduce_max(Parameters->get_master_lmhead().abs_max());
     }
     comm.wait_on_comms(main_stream);
-    Parameters->end_optimizer(rs->mTempStack);
+    OptimizerState->end_optimizer(rs->Stack);
+    Parameters->end_optimizer(rs->Stack);
     CUDA_CHECK(cudaEventRecord(rs->OptimizerDone, main_stream));
     if(Options.TriggerTimingEvents) {
         CUDA_CHECK(cudaEventRecord(rs->TimingOptimizerEnd, main_stream));
@@ -820,14 +822,17 @@ void LLamaModel::allocate_run_state(const LLamaOptions& options, NCCLCommunicato
         acts = ::allocate_run_state(Config, options, B, T, stack, Allocator);
     }
 
+    OptimizerState = std::make_unique<LLamaOptimizerStateManager>(Config, options, acts.MainStream, comm, *Allocator);
+
     Parameters->begin_optimizer(stack, comm.stream());
-    printf("Allocated %zu MiB of run state\n", stack.bytes_used()  / 1024/ 1024);
+    OptimizerState->begin_optimizer(stack);
+    OptimizerState->end_optimizer(stack);
     Parameters->end_optimizer(stack);
 
     {
         auto ctx = Allocator->with_context("Stack");
         long required_size = stack.max_utilization();
-        acts.mTempStack = DeviceMemoryStack{Allocator->allocate(ETensorDType::BYTE, "stack", {required_size}).Data, (std::size_t)required_size, dev};
+        acts.Stack = DeviceMemoryStack{Allocator->allocate(ETensorDType::BYTE, "stack", {required_size}).Data, (std::size_t)required_size, dev};
     }
 
     {
@@ -837,7 +842,6 @@ void LLamaModel::allocate_run_state(const LLamaOptions& options, NCCLCommunicato
 
     OptimizerRNG = std::minstd_rand{42};
     RunState = std::make_unique<LLamaRunState>(std::move(acts));
-    OptimizerState = std::make_unique<LLamaOptimizerStateManager>(Config, options, RunState->MainStream, comm, *Allocator);
     comm.barrier();     // make sure *all* GPUs have allocated the model before returning
 }
 

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -735,8 +735,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         CUDA_CHECK(cudaEventRecord(rs->TimingOptimizerStart, main_stream));
     }
 
-    // make sure we can run abs_max again
-    Parameters->reset_scales(main_stream);
+    Parameters->begin_optimizer(rs->mTempStack, rs->MainStream);
 
     // grad_scale gets deposited into NormBuffer[1] and can be used on main_stream after this.
     calculate_gradient_norm(comm, grad_clip);
@@ -800,6 +799,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         comm.reduce_max(Parameters->get_master_lmhead().abs_max());
     }
     comm.wait_on_comms(main_stream);
+    Parameters->end_optimizer(rs->mTempStack);
     CUDA_CHECK(cudaEventRecord(rs->OptimizerDone, main_stream));
     if(Options.TriggerTimingEvents) {
         CUDA_CHECK(cudaEventRecord(rs->TimingOptimizerEnd, main_stream));
@@ -808,11 +808,26 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
 
 void LLamaModel::allocate_run_state(const LLamaOptions& options, NCCLCommunicator& comm, int B, int T) {
     NVTX_RANGE_FN();
+
+    // create a dummy stack and simulate the way we're going to use temporaries later, to determine how much we need to allocate
+    int dev;
+    CUDA_CHECK(cudaGetDevice(&dev));
+    DeviceMemoryStack stack(nullptr, 1024 * 1024 * 1024 * 1024ll, dev);
+
     LLamaRunState acts;
     {
         auto ctx = Allocator->with_context("Activations");
-        acts = ::allocate_run_state(Config, options, B, T, Allocator);
+        acts = ::allocate_run_state(Config, options, B, T, stack, Allocator);
+    }
 
+    Parameters->begin_optimizer(stack, comm.stream());
+    printf("Allocated %zu MiB of run state\n", stack.bytes_used()  / 1024/ 1024);
+    Parameters->end_optimizer(stack);
+
+    {
+        auto ctx = Allocator->with_context("Stack");
+        long required_size = stack.max_utilization();
+        acts.mTempStack = DeviceMemoryStack{Allocator->allocate(ETensorDType::BYTE, "stack", {required_size}).Data, (std::size_t)required_size, dev};
     }
 
     {

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -8,6 +8,7 @@
 #include "llama_model.h"
 #include "utilities/comm.h"
 #include "kernels/kernels.h"
+#include "utilities/stack.h"
 
 void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_stream) {
     if((!mOffloadM && !mOffloadV) || mUseZeroCopy) return;
@@ -59,6 +60,54 @@ void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_s
 
     if(stat.Fetch) {
         CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
+    }
+}
+
+void LLamaOptimizerStateManager::begin_optimizer(DeviceMemoryStack& memory) {
+    if(mOffloadM &&! mUseZeroCopy) {
+        ETensorDType m_type = mOptM.Blocks[0].LN1_w.DType;
+        matrix_params_from_stack(mOptMBuffer[0], mConfig, m_type, mRank, mWorld, memory);
+        non_matrix_params_from_stack(mOptMBuffer[0], mConfig, m_type, mRank, mWorld, memory);
+        matrix_params_from_stack(mOptMBuffer[1], mConfig, m_type, mRank, mWorld, memory);
+        non_matrix_params_from_stack(mOptMBuffer[1], mConfig, m_type, mRank, mWorld, memory);
+    }
+
+    if(mOffloadV &&! mUseZeroCopy) {
+        ETensorDType v_type = mOptV.Blocks[0].LN1_w.DType;
+        matrix_params_from_stack(mOptVBuffer[0], mConfig, v_type, mRank, mWorld, memory);
+        non_matrix_params_from_stack(mOptVBuffer[0], mConfig, v_type, mRank, mWorld, memory);
+        matrix_params_from_stack(mOptVBuffer[1], mConfig, v_type, mRank, mWorld, memory);
+        non_matrix_params_from_stack(mOptVBuffer[1], mConfig, v_type, mRank, mWorld, memory);
+    }
+}
+void LLamaOptimizerStateManager::end_optimizer(DeviceMemoryStack& memory) {
+    auto free_non_matrix = [&](sLLamaBlockWeights<TensorShard>& buf) {
+        if(buf.Attn_QKV_b.has_value()) {
+            memory.free(buf.Attn_QKV_b.value());
+        }
+        memory.free(buf.LN2_w);
+        memory.free(buf.LN1_w);
+    };
+
+     auto free_matrix = [&](sLLamaBlockWeights<TensorShard>& buf) {
+         memory.free(buf.MLP_Down_w);
+         memory.free(buf.MLP_Up_w);
+         memory.free(buf.Attn_Out_w);
+         memory.free(buf.Attn_QKV_w);
+    };
+
+    if(mOffloadV &&! mUseZeroCopy) {
+        free_non_matrix(mOptVBuffer[1]);
+        free_matrix(mOptVBuffer[1]);
+        free_non_matrix(mOptVBuffer[0]);
+        free_matrix(mOptVBuffer[0]);
+    }
+
+    if(mOffloadM &&! mUseZeroCopy) {
+        free_non_matrix(mOptMBuffer[1]);
+        free_matrix(mOptMBuffer[1]);
+        free_non_matrix(mOptMBuffer[0]);
+        free_matrix(mOptMBuffer[0]);
     }
 }
 
@@ -209,7 +258,7 @@ sLLamaWeights allocate_scales(LLamaConfig config, int shard_idx, int num_shards,
 }
 
 LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc):
-    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV), mUseZeroCopy(options.UseZeroCopy)
+    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV), mUseZeroCopy(options.UseZeroCopy), mConfig(cfg), mRank(comm.rank()), mWorld(comm.world_size())
 {
     {
         auto ctx = alloc.with_context("Adam M");
@@ -218,13 +267,6 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOpt
         c.DType = options.OptMomentumType;
         mOptM = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
         zero_opt_state(mOptM, stream);
-
-        if(options.OffloadOptM && !mUseZeroCopy) {
-            mOptMBuffer[0] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
-                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
-            mOptMBuffer[1] = allocate_block_shard(c, options.OptMomentumType, options.OptMomentumType,
-                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
-        }
 
         if(options.OptMomentumType == ETensorDType::FP8_E4M3) {
             mOptMScales = allocate_scales(c, comm.rank(), comm.world_size(), alloc);
@@ -240,12 +282,6 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(LLamaConfig cfg, LLamaOpt
         c.DType = options.OptVarianceType;
         mOptV = allocate_weights(c, alloc_type, comm.rank(), comm.world_size(), alloc);
         zero_opt_state(mOptV, stream);
-        if(options.OffloadOptV && !mUseZeroCopy){
-            mOptVBuffer[0] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
-                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
-            mOptVBuffer[1] = allocate_block_shard(c, options.OptVarianceType, options.OptVarianceType,
-                                                  EAllocationType::ON_DEVICE, comm.rank(), comm.world_size(), alloc);
-        }
     }
 
     if((options.OffloadOptM || options.OffloadOptV) && !mUseZeroCopy) {

--- a/src/models/llama_optimizer.h
+++ b/src/models/llama_optimizer.h
@@ -15,6 +15,9 @@ public:
     sLLamaNonBlockWeights<TensorShard>& non_block_m();
     sLLamaNonBlockWeights<TensorShard>& non_block_v();
 
+    void begin_optimizer(DeviceMemoryStack& memory);
+    void end_optimizer(DeviceMemoryStack& memory);
+
     sLLamaWeights& full_m() { return mOptM; }
     sLLamaWeights& scales_m() { return mOptMScales; }
     sLLamaWeights& full_v() { return mOptV; }
@@ -24,6 +27,7 @@ public:
     sLLamaBlockWeights<TensorShard>& get_block_v(int layer_idx, cudaStream_t stream);
     void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
 private:
+    LLamaConfig mConfig;
     sLLamaWeights mOptM;
     sLLamaWeights mOptV;
     std::array<sLLamaBlockWeights<TensorShard>, 2> mOptMBuffer;
@@ -43,6 +47,9 @@ private:
     bool mOffloadM;
     bool mOffloadV;
     bool mUseZeroCopy;
+
+    int mRank;
+    int mWorld;
 
     sLLamaBlockWeights<TensorShard>& get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf);
     void store_one_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream, sLLamaBlockWeights<TensorShard>& buf, sLLamaBlockWeights<TensorShard>& dst);

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -254,7 +254,7 @@ void LLamaRunState::release_res_ffn(int layer_idx, cudaStream_t main_stream) {
     CUDA_CHECK(cudaEventRecord(status.Event, main_stream));
 }
 
-void LLamaRunState::init(LLamaConfig config, long B, long T) {
+void LLamaRunState::init(LLamaConfig config, long B, long T, DeviceMemoryStack& stack) {
     long V = config.VocabSize;
     long C = config.HiddenSize;
     long H = config.IntermediateSize;
@@ -375,39 +375,33 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
         }
     }
 
-    // create a dummy stack and simulate the way we're going to use temporaries later, to determine how much we need to allocate
-    DeviceMemoryStack activation_stack(nullptr, 1024*1024*1024*1024ll, Inputs.Device);
-
     bool use_fp8 = Options.grad_dtype() == ETensorDType::FP8_E4M3 || Options.grad_dtype() == ETensorDType::FP8_E5M2;
     auto bw_qmm = [&](int B, int T, int C, int OC) {
         if(use_fp8) {
-            auto wgt_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, OC});
-            activation_stack.free(wgt_tp.Data);
-            auto act_tp = activation_stack.allocate(ETensorDType::FP8_E4M3, {C, B * T});
-            auto grd_tp = activation_stack.allocate(Options.grad_dtype(), {OC, B * T});
-            activation_stack.free(grd_tp.Data);
-            activation_stack.free(act_tp.Data);
+            auto wgt_tp = stack.allocate(ETensorDType::FP8_E4M3, {C, OC});
+            stack.free(wgt_tp.Data);
+            auto act_tp = stack.allocate(ETensorDType::FP8_E4M3, {C, B * T});
+            auto grd_tp = stack.allocate(Options.grad_dtype(), {OC, B * T});
+            stack.free(grd_tp.Data);
+            stack.free(act_tp.Data);
         }
     };
 
     // simulate to determine required stack size
-    auto ws = activation_stack.allocate(CuDNNWorkspace.bytes());
-    activation_stack.free(activation_stack.allocate(DActs[0].DQKV.Value.bytes()));   // attention
-    activation_stack.free(ws);   // attention
+    auto ws = stack.allocate(CuDNNWorkspace.bytes());
+    stack.free(stack.allocate(DActs[0].DQKV.Value.bytes()));   // attention
+    stack.free(ws);   // attention
 
-    auto dswi = activation_stack.allocate(DActs[0].DSwiGLU.bytes());
+    auto dswi = stack.allocate(DActs[0].DSwiGLU.bytes());
     bw_qmm(B, T, H, C);         // backward qmm swiglu
-    activation_stack.free(dswi);
+    stack.free(dswi);
 
     if(use_fp8) {
-        auto dupq = activation_stack.allocate(DActs[0].DMlpUp.Quant->bytes());
+        auto dupq = stack.allocate(DActs[0].DMlpUp.Quant->bytes());
         bw_qmm(B, T, C, 2 * H);     // backward qmm up
-        activation_stack.free(dupq);
+        stack.free(dupq);
     }
-    activation_stack.free(activation_stack.allocate(Output.bytes()));  // lm-head
-
-    long required_size = activation_stack.max_utilization();
-    mTempStack = DeviceMemoryStack{alloc->allocate(ETensorDType::BYTE, "temporaries", {required_size}).Data, (std::size_t)required_size, Inputs.Device};
+    stack.free(stack.allocate(Output.bytes()));  // lm-head
 
     MatmulScales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
 
@@ -418,9 +412,9 @@ void LLamaRunState::init(LLamaConfig config, long B, long T) {
     }
 }
 
-LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc) {
+LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, DeviceMemoryStack& stack, std::shared_ptr<TensorAllocator> alloc) {
     LLamaRunState state{options, std::move(alloc)};
-    state.init(config, B, T);
+    state.init(config, B, T, stack);
     return state;
 }
 

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -419,19 +419,19 @@ LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long 
 }
 
 Tensor LLamaRunState::temp_alloc(ETensorDType dtype, const std::vector<long>& shape) {
-    return  mTempStack.allocate(dtype, shape);
+    return  Stack.allocate(dtype, shape);
 }
 
 void LLamaRunState::temp_acquire(Tensor& target) {
-    if(target.Device != mTempStack.device_id()) {
+    if(target.Device != Stack.device_id()) {
         throw std::logic_error("device mismatch");
     }
 
-    target.Data = mTempStack.allocate(target.bytes());
+    target.Data = Stack.allocate(target.bytes());
 }
 
 void LLamaRunState::temp_free(Tensor& tensor) {
-    mTempStack.free(tensor);
+    Stack.free(tensor);
 }
 
 void LLamaRunState::setup_timing_events(int micro_steps) {

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -119,7 +119,7 @@ struct LLamaRunState {
     void temp_acquire(Tensor& target);
     void temp_free(Tensor& tensor);
 
-    DeviceMemoryStack mTempStack;
+    DeviceMemoryStack Stack;
 
     // cached GPU info
     cudaDeviceProp DeviceProp;

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -156,10 +156,10 @@ struct LLamaRunState {
     cudnnHandle_t CudnnHandle;
     cublasLtHandle_t CublasLtHandle;
 
-    void init(LLamaConfig config, long B, long T);
+    void init(LLamaConfig config, long B, long T, DeviceMemoryStack& stack);
 };
 
-LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, std::shared_ptr<TensorAllocator> alloc);
+LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, DeviceMemoryStack& stack, std::shared_ptr<TensorAllocator> alloc);
 
 float get_loss(LLamaRunState& acts);
 float get_norm(LLamaRunState& acts);

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -39,6 +39,44 @@ void allocate_matrix_params(sLLamaBlockWeights<T>& target, const LLamaConfig& co
     target.MLP_Down_w = alloc.allocate_shard(dtype, shard_idx, num_shards, "mlp_down_w", {C, H}, kind);
 }
 
+template<class T>
+void matrix_params_from_stack(sLLamaBlockWeights<T>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
+    long C = config.HiddenSize;
+    long H = config.IntermediateSize;
+
+    auto create_matrix_shard = [&](long rows, long cols) {
+        Tensor raw = memory.allocate(dtype, {div_exact(rows, (long)num_shards), cols});
+        return TensorShard{raw, shard_idx, num_shards, std::vector<long>{rows, cols}};
+    };
+
+    long head_size = C / config.NumQueryHeads;
+    long attn_intermediate_size = (config.NumQueryHeads + 2 * config.NumKeyValHeads) * head_size;
+    target.Attn_QKV_w = create_matrix_shard(attn_intermediate_size, C);
+    target.Attn_Out_w = create_matrix_shard(C, C);
+    target.MLP_Up_w = create_matrix_shard(2 * H, C);
+    target.MLP_Down_w = create_matrix_shard(C, H);
+}
+
+template<class T>
+void non_matrix_params_from_stack(sLLamaBlockWeights<T>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
+    long C = config.HiddenSize;
+    long HS = config.head_size();
+
+    auto create_vector_shard = [&](long elems) {
+        Tensor raw = memory.allocate(dtype, {div_exact(elems, (long)num_shards)});
+        return TensorShard{raw, shard_idx, num_shards, std::vector<long>{elems}};
+    };
+
+    target.LN1_w = create_vector_shard(C);
+    target.LN2_w = create_vector_shard(C);
+    long attn_intermediate_size = (config.NumQueryHeads + 2 * config.NumKeyValHeads) * HS;
+    if(config.UseQKVBias) {
+        target.Attn_QKV_b = create_vector_shard(attn_intermediate_size);
+    } else {
+        target.Attn_QKV_b = std::nullopt;
+    }
+}
+
 std::size_t aligned_size(std::size_t raw, int num_shards) {
     return div_ceil(div_exact(raw, static_cast<std::size_t>(num_shards)), static_cast<std::size_t>(4096)) * 4096;
 }
@@ -163,7 +201,7 @@ sLLamaWeights allocate_weights(const LLamaConfig& config, EAllocationType kind, 
 
 LLamaWeightsManager::LLamaWeightsManager(const LLamaConfig& config, const LLamaOptions& options, int rank, int world) :
     mMasterDType(options.MasterDType.value_or(config.DType)), mWorkMatDType(options.matmul_dtype()),
-    mShardIdx(rank), mNumShards(world)
+    mShardIdx(rank), mNumShards(world), mConfig(config)
 {
     mEmbStatus.DoneEvent = create_named_event("emb_done");
     mLnfStatus.DoneEvent = create_named_event("lnf_done");
@@ -217,29 +255,6 @@ std::pair<float*, float*> LLamaWeightsManager::get_scales_for_block(int layer_id
 void LLamaWeightsManager::setup_master_buffers(const LLamaConfig& config, TensorAllocator& alloc) {
     if (mOffloadMaster && !mUseZeroCopy) {
         for(int i = 0; i < 2; ++i) {
-            auto& buf = mMasterDeviceDoubleBuffer.at(i);
-            if (mWorkMatDType != mMasterDType) {
-                auto c = alloc.with_context("Master");
-                allocate_matrix_params(buf, config, mMasterDType, EAllocationType::ON_DEVICE, mShardIdx, mNumShards,
-                                       alloc);
-            } else {
-                // note: the actual data pointers will be overwritten before use, so this is safe
-                buf.Attn_QKV_w = mMaster.Blocks[0].Attn_QKV_w;
-                buf.Attn_Out_w = mMaster.Blocks[0].Attn_Out_w;
-                buf.MLP_Up_w = mMaster.Blocks[0].MLP_Up_w;
-                buf.MLP_Down_w = mMaster.Blocks[0].MLP_Down_w;
-            }
-
-            if (config.DType != mMasterDType) {
-                auto c = alloc.with_context("Master");
-                allocate_non_matrix_params(buf, config, mMasterDType, EAllocationType::ON_DEVICE, mShardIdx,
-                                           mNumShards, alloc);
-            } else {
-                buf.LN1_w = mMaster.Blocks[0].LN1_w;
-                buf.LN2_w = mMaster.Blocks[0].LN2_w;
-                buf.Attn_QKV_b = mMaster.Blocks[0].Attn_QKV_b;
-            }
-
             mMasterDeviceBufferStatus.at(i) = sGatherData{i, create_named_event(("master_event_" + std::to_string(i)).c_str())};
         }
     }
@@ -264,6 +279,55 @@ TensorShard& LLamaWeightsManager::get_master_lmhead() {
 
 TensorShard& LLamaWeightsManager::get_master_lnf_w() {
     return mMaster.NonBlocks.LNF_w;
+}
+
+void LLamaWeightsManager::begin_optimizer(DeviceMemoryStack& memory, cudaStream_t stream) {
+    reset_scales(stream);
+    if (mOffloadMaster && !mUseZeroCopy) {
+        for (int i = 0; i < 2; ++i) {
+            auto& buf = mMasterDeviceDoubleBuffer.at(i);
+            if (mMaster.Blocks[0].Attn_QKV_w.Device == -1) {
+                matrix_params_from_stack(buf, mConfig, mMasterDType, mShardIdx, mNumShards, memory);
+            } else {
+                // note: the actual data pointers will be overwritten before use, so this is safe
+                buf.Attn_QKV_w = mMaster.Blocks[0].Attn_QKV_w;
+                buf.Attn_Out_w = mMaster.Blocks[0].Attn_Out_w;
+                buf.MLP_Up_w = mMaster.Blocks[0].MLP_Up_w;
+                buf.MLP_Down_w = mMaster.Blocks[0].MLP_Down_w;
+            }
+
+            if (mMaster.Blocks[0].LN1_w.Device == -1) {
+                non_matrix_params_from_stack(buf, mConfig, mMasterDType, mShardIdx, mNumShards, memory);
+            } else {
+                buf.LN1_w = mMaster.Blocks[0].LN1_w;
+                buf.LN2_w = mMaster.Blocks[0].LN2_w;
+                buf.Attn_QKV_b = mMaster.Blocks[0].Attn_QKV_b;
+            }
+        }
+    }
+}
+
+void LLamaWeightsManager::end_optimizer(DeviceMemoryStack& memory) {
+    if (mOffloadMaster && !mUseZeroCopy) {
+        // it's a stack, so we need to free in reverse order
+        for (int i = 1; i >= 0; --i) {
+            auto& buf = mMasterDeviceDoubleBuffer.at(i);
+            if (mMaster.Blocks[0].LN1_w.Device == -1) {
+                if(buf.Attn_QKV_b.has_value()) {
+                    memory.free(buf.Attn_QKV_b.value());
+                }
+                memory.free(buf.LN2_w);
+                memory.free(buf.LN1_w);
+            }
+
+            if (mMaster.Blocks[0].Attn_QKV_w.Device == -1) {
+                memory.free(buf.MLP_Down_w);
+                memory.free(buf.MLP_Up_w);
+                memory.free(buf.Attn_Out_w);
+                memory.free(buf.Attn_QKV_w);
+            }
+        }
+    }
 }
 
 void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_stream) {

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -39,8 +39,7 @@ void allocate_matrix_params(sLLamaBlockWeights<T>& target, const LLamaConfig& co
     target.MLP_Down_w = alloc.allocate_shard(dtype, shard_idx, num_shards, "mlp_down_w", {C, H}, kind);
 }
 
-template<class T>
-void matrix_params_from_stack(sLLamaBlockWeights<T>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
+void matrix_params_from_stack(sLLamaBlockWeights<TensorShard>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
     long C = config.HiddenSize;
     long H = config.IntermediateSize;
 
@@ -57,8 +56,7 @@ void matrix_params_from_stack(sLLamaBlockWeights<T>& target, const LLamaConfig& 
     target.MLP_Down_w = create_matrix_shard(C, H);
 }
 
-template<class T>
-void non_matrix_params_from_stack(sLLamaBlockWeights<T>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
+void non_matrix_params_from_stack(sLLamaBlockWeights<TensorShard>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory) {
     long C = config.HiddenSize;
     long HS = config.head_size();
 

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -190,6 +190,9 @@ sLLamaWeights allocate_weights(const LLamaConfig& config, EAllocationType kind, 
 sLLamaBlockWeights<TensorShard> shard_block(const sLLamaBlockWeights<Tensor>& block, int shard_idx, int num_shards);
 sLLamaNonBlockWeights<TensorShard> shard_non_block(const sLLamaNonBlockWeights<Tensor>& block, int shard_idx, int num_shards);
 
+void matrix_params_from_stack(sLLamaBlockWeights<TensorShard>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory);
+void non_matrix_params_from_stack(sLLamaBlockWeights<TensorShard>& target, const LLamaConfig& config, ETensorDType dtype, int shard_idx, int num_shards, DeviceMemoryStack& memory);
+
 std::size_t bytes_for_block(const LLamaConfig& config, ETensorDType matrix_dtype, ETensorDType other_dtype, int num_shards);
 std::size_t bytes_for_block_matrices(const LLamaConfig& config, ETensorDType dtype, int num_shards);
 std::size_t bytes_for_block_non_matrix(const LLamaConfig& config, ETensorDType dtype, int num_shards);

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -10,12 +10,13 @@
 
 #include "utilities/tensor.h"
 #include "utilities/tensor_container.h"
+#include "llama_config.h"
 
-struct LLamaConfig;
 struct LLamaOptions;
 struct LLamaRunState;
 class TensorAllocator;
 class NCCLCommunicator;
+class DeviceMemoryStack;
 enum class EAllocationType : int;
 typedef struct CUevent_st* cudaEvent_t;
 
@@ -64,6 +65,9 @@ public:
     void invalidate();
     void reset_scales(cudaStream_t stream);
     std::pair<float*, float*> get_scales_for_block(int layer_idx);
+
+    void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t stream);
+    void end_optimizer(DeviceMemoryStack& memory);
 
     // Weight shards that get updated by the optimizer
     TensorShard& get_master_embeddings();
@@ -158,6 +162,7 @@ protected:
 
     void convert_dtype_for_gather(TensorShard& src, TensorShard& qnt, bool& convert, LLamaRunState& run_state);
 
+    LLamaConfig mConfig;
     long HQ;    // number of query heads
     long HKV;   // number of key/value heads
     int mShardIdx;
@@ -171,12 +176,6 @@ protected:
 
     bool mOffloadMaster;
     bool mUseZeroCopy;
-};
-
-class LLamaOptimizerParamManager {
-public:
-private:
-
 };
 
 sLLamaNonBlockWeights<Tensor> allocate_non_block_full(LLamaConfig config, ETensorDType dtype, EAllocationType kind, TensorAllocator& alloc);

--- a/src/utilities/stack.cpp
+++ b/src/utilities/stack.cpp
@@ -20,7 +20,7 @@ std::byte* DeviceMemoryStack::allocate(std::size_t amount) {
 
     mAlloc.emplace_back(mTop, aligned_amount);
     mTop = new_top;
-    mMaxUtilization = std::max(mMaxUtilization, mCapacity - unused_capacity());
+    mMaxUtilization = std::max(mMaxUtilization, bytes_used());
     return mAlloc.back().first;
 }
 
@@ -42,6 +42,10 @@ void DeviceMemoryStack::free(std::byte* ptr) {
 
 std::size_t DeviceMemoryStack::unused_capacity() const {
     return mCapacity - (mTop - mBackingMemory);
+}
+
+std::size_t DeviceMemoryStack::bytes_used() const {
+    return mCapacity - unused_capacity();
 }
 
 std::size_t DeviceMemoryStack::max_utilization() const {

--- a/src/utilities/stack.h
+++ b/src/utilities/stack.h
@@ -21,6 +21,7 @@ public:
     void free(Tensor& tensor);
 
     std::size_t unused_capacity() const;
+    std::size_t bytes_used() const;
     std::size_t max_utilization() const;
     int device_id() const;
 private:


### PR DESCRIPTION
Instead of allocating fresh buffers for optimizer step double buffering, reuse existing (and unused, at the time) memory from the activation stack.