### PR TITLE
Mlp up stack

### DIFF
--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -355,7 +355,7 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         CUDA_CHECK(cudaStreamWaitEvent(rs->SideStream, rs->BackwardDone, 0));
         CUDA_CHECK(cudaMemcpyAsync(rs->Targets.Data, targets.Data, targets.bytes(), cudaMemcpyHostToDevice, rs->SideStream));
         CUDA_CHECK(cudaEventRecord(rs->TransferDone, rs->SideStream));
-        CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->TransferDone, 0));
+        // we will wait in _backward_lmhead for this transfer to be done.
     }
 
     bool last_step = micro_step == grad_accum_steps - 1;
@@ -485,6 +485,11 @@ void LLamaModel::_backward_lmhead(long B, long T, int micro_step, int grad_accum
         matmul(rs->Output, Parameters->get_head(main_stream), lnf_slice, std::nullopt,
                nullptr, nullptr, rs->CublasLtHandle, rs->CuBlasWorkspace, V, nano_batch_size, C, EMMTranspose::TN,
                false, main_stream);
+
+        if(nano_step == 0) {
+            // make sure Targets have been copied
+            CUDA_CHECK(cudaStreamWaitEvent(main_stream, rs->TransferDone, 0));
+        }
 
         // accumulate the losses inside rs->losses, and kick off the backward pass inside the fused classifier
         fused_classifier(rs->Output, losses, d_loss, tgt, nano_batch_size, V, Vp, true, main_stream);

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -146,9 +146,11 @@ void LLamaModel::forward(Tensor inputs, NCCLCommunicator& comm, int micro_step) 
             rs->mark_res_ffn_ready(l-1, main_stream);
         }
 
+        rs->Acts[l].MlpUp = rs->acquire_mlp_up(l);
         trace_or_execute_cuda_graph([&](){_forward_block(wgt, rs->Acts[l], residual);},
             main_stream, rs->ForwardBlockGraph, rs->Options.UseCudaGraphs);
         Parameters->release_block(l, main_stream);
+        rs->release_mlp_up(rs->Acts[l].MlpUp);
         if(l > 0) {
             rs->put_res_ffn(l-1, rs->SideStream);
         }
@@ -411,10 +413,13 @@ void LLamaModel::backward(Tensor inputs, Tensor targets, NCCLCommunicator& comm,
         auto& weights = Parameters->get_block(l, main_stream);
         auto& d_acts = rs->DActs.at(l);
         Tensor residual = l == 0 ? rs->Encoded : rs->get_res_ffn(l - 1, main_stream);
+        rs->Acts[l].MlpUp = rs->acquire_mlp_up(l);
+        rs->DActs[l].DMlpUp.Value = rs->Acts[l].MlpUp;
         trace_or_execute_cuda_graph([&]() {
             _recompute_block(weights, rs->Acts[l], residual);
             _backward_block(accumulate, weights, dw, rs->Acts[l], rs->DActs[l]);
             }, main_stream, rs->BackwardBlockGraph, rs->Options.UseCudaGraphs);
+        rs->release_mlp_up(rs->Acts[l].MlpUp);
 
         if(l > 0) {
             auto& prev_dacts = rs->DActs.at(l - 1);

--- a/src/models/llama_run_state.cpp
+++ b/src/models/llama_run_state.cpp
@@ -99,7 +99,9 @@ LLamaRunState::LayerActivations RunStateBuilder::allocate_basic_fwd_tensors(Tens
     Tensor atto = allocate_or_reuse(true, lnf, Config.DType, "att_o", B, T, C);
     bool reuse_swiglu = Options.RecomputeSwiGLu || quant || Options.RecomputeFFN;
     Tensor swiglu_v = allocate_or_reuse(reuse_swiglu, tSwiGluBuffer, Config.DType, "swiglu", B, T, H);
-    Tensor mlp_up = allocate_or_reuse(Options.RecomputeFFN, tMlpUpBuffer, Config.DType, "mlp_up", B, T, 2 * H);
+    Tensor mlp_up;
+    if(!Options.RecomputeFFN)
+        mlp_up = allocate_or_reuse(Options.RecomputeFFN, tMlpUpBuffer, Config.DType, "mlp_up", B, T, 2 * H);
 
     QuantizableTensor ln1 = {ln1_v, std::nullopt};
     QuantizableTensor ln2 = {ln2_v, std::nullopt};
@@ -388,6 +390,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T, DeviceMemoryStack& 
     };
 
     // simulate to determine required stack size
+    auto mlp_up = stack.allocate(Config.DType, {B, T, 2 * Config.IntermediateSize}, "mlp_up");
     auto ws = stack.allocate(CuDNNWorkspace.bytes(), "workspace");
     stack.free(stack.allocate(DActs[0].DQKV.Value.bytes(), "dqkv"));   // attention
     stack.free(ws);   // attention
@@ -401,6 +404,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T, DeviceMemoryStack& 
         bw_qmm(B, T, C, 2 * H);     // backward qmm up
         stack.free(dupq);
     }
+    stack.free(mlp_up);
     stack.free(stack.allocate(Output.bytes(), "output"));  // lm-head
 
     MatmulScales = alloc->allocate(ETensorDType::FP32, "mm_scales", {2});
@@ -413,7 +417,7 @@ void LLamaRunState::init(LLamaConfig config, long B, long T, DeviceMemoryStack& 
 }
 
 LLamaRunState allocate_run_state(LLamaConfig config, LLamaOptions options, long B, long T, DeviceMemoryStack& stack, std::shared_ptr<TensorAllocator> alloc) {
-    LLamaRunState state{options, std::move(alloc)};
+    LLamaRunState state{config, B, T, options, std::move(alloc)};
     state.init(config, B, T, stack);
     return state;
 }
@@ -442,6 +446,20 @@ void LLamaRunState::setup_timing_events(int micro_steps) {
         TimingHeadEnd.push_back(create_named_event(("timing_head_" + std::to_string(i) + "_end").c_str(), true));
         TimingBackwardStart.push_back(create_named_event(("timing_bwd_" + std::to_string(i) + "_start").c_str(), true));
         TimingBackwardEnd.push_back(create_named_event(("timing_bwd_" + std::to_string(i) + "_end").c_str(), true));
+    }
+}
+
+Tensor LLamaRunState::acquire_mlp_up(int layer) {
+    if(Options.RecomputeFFN) {
+        return Stack.allocate(Options.ModelType.value(), {B, T, 2 * Config.IntermediateSize});
+    } else {
+        return Acts[layer].MlpUp;
+    }
+}
+
+void LLamaRunState::release_mlp_up(Tensor& mlp_up) {
+    if(Options.RecomputeFFN) {
+        Stack.free(mlp_up);
     }
 }
 

--- a/src/models/llama_run_state.h
+++ b/src/models/llama_run_state.h
@@ -57,6 +57,9 @@ struct LLamaRunState {
     using LayerActivations = ::sLLamaLayerActivations;
     using LayerGradients = ::sLLamaLayerGradients;
 
+    LLamaConfig Config;
+    long B;
+    long T;
     LLamaOptions Options;
     std::shared_ptr<TensorAllocator> Allocator;
 
@@ -118,6 +121,9 @@ struct LLamaRunState {
     Tensor temp_alloc(ETensorDType dtype, const std::vector<long>& shape);
     void temp_acquire(Tensor& target);
     void temp_free(Tensor& tensor);
+
+    Tensor acquire_mlp_up(int layer);
+    void release_mlp_up(Tensor& mlp_up);
 
     DeviceMemoryStack Stack;
 

--- a/src/training/logging.h
+++ b/src/training/logging.h
@@ -17,7 +17,6 @@ struct GPUUtilInfo;
 struct sSegmentMemory;
 class NCCLCommunicator;
 class DataLoader;
-class DeviceMemoryStack;
 enum class ETensorDType : int;
 
 class TrainingRunLogger

--- a/train.cpp
+++ b/train.cpp
@@ -90,6 +90,7 @@ struct TrainingRunner {
     LLamaOptions Options;
 
     int LogAllocations = -1;
+    std::chrono::steady_clock::time_point BeginStartup;
 
     void load_training_config(int argc, const char** argv);
     void launch_training(int argc, const char** argv);
@@ -97,6 +98,7 @@ struct TrainingRunner {
 };
 
 void TrainingRunner::load_training_config(int argc, const char** argv) {
+    BeginStartup = std::chrono::steady_clock::now();
     CLI::App app;
 
     std::string matmul_dtype = "";
@@ -442,6 +444,10 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
     } else {
         throw std::invalid_argument("Unknown learning rate schedule: " + LrScheduleType);
     }
+
+    fprintf(stdout, "Starting training for %d steps (%f epochs in total)\n", MaxSteps, float(MaxSteps) / steps_per_epoch);
+    fprintf(stdout, "Setup took %ld seconds\n", std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - BeginStartup).count());
+
 
     for (int step = latest_step; step < MaxSteps; ++step) {
         bool run_eval = false;


### PR DESCRIPTION
Move `mlp_up` on the stack for cases where it is not persistent; we can then overlap its memory with the output logits.