### PR TITLE
vector_reduce_sr kernel gradient reduction

### DIFF
--- a/src/kernels/kernels.cpp
+++ b/src/kernels/kernels.cpp
@@ -188,6 +188,14 @@ void vector_add_sr(Tensor& dest, const Tensor& left, const Tensor& right, float 
     }
 }
 
+void vector_reduce_sr(Tensor& dest, const Tensor& src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream) {
+    if(dest.DType == ETensorDType::FP32) {
+        vector_reduce_sr(dest.get<float>(), src.get<float>(), scale, n_shards, skip, nelem, accumulate, seed, stream);
+    } else if(dest.DType == ETensorDType::BF16) {
+        vector_reduce_sr(dest.get<nv_bfloat16>(), src.get<nv_bfloat16>(), scale, n_shards, skip, nelem, accumulate, seed, stream);
+    }
+}
+
 void abs_max(float* scale, const Tensor& in, long N, const cudaDeviceProp& dp, cudaStream_t stream) {
     if (in.DType == ETensorDType::FP32) {
         abs_max(scale, in.get<float>(), N, dp, stream);

--- a/src/kernels/kernels.h
+++ b/src/kernels/kernels.h
@@ -231,6 +231,15 @@ void vector_add_sr(float* dest, const float* left, const float* right, float sca
 void vector_add_sr(nv_bfloat16* dest, const nv_bfloat16* left, const nv_bfloat16* right, float scale, long nelem, unsigned seed, cudaStream_t stream);
 void vector_add_sr(Tensor& dest, const Tensor& left, const Tensor& right, float scale, long nelem, unsigned seed, cudaStream_t stream);
 
+//! \fn void vector_reduce_sr(Tensor& dest, const Tensor& src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream);
+//! \brief Reduce shards of tensor using stochastic rounding
+//! \details Interprets `src` as a tensor of `n_shard` shards of size `nelem` each. The shards are summed together, and the result is either written to (`accumulate = false`)
+//! or added into (`accumulate = true`) `dest`, after being scaled by `scale`. All intermediate calculations are done in float precision, and stochastic rounding using the
+//! provided `seed` is applied before writing to `dest`. The `skip` parameter allows to skip one of the shards. Set to -1 to disable skipping.
+void vector_reduce_sr(float* dest, const float* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream);
+void vector_reduce_sr(nv_bfloat16* dest, const nv_bfloat16* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream);
+void vector_reduce_sr(Tensor& dest, const Tensor& src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream);
+
 void fill_normal(float* dst, std::size_t count, float mean, float std, unsigned long long seed, unsigned long long subsequence, cudaStream_t stream);
 void fill_normal(nv_bfloat16* dst, std::size_t count, float mean, float std, unsigned long long seed, unsigned long long subsequence, cudaStream_t stream);
 void fill_normal(Tensor& dest, std::size_t count, float mean, float std, unsigned long long seed, unsigned long long subsequence, cudaStream_t stream);

--- a/src/kernels/vector_add.cu
+++ b/src/kernels/vector_add.cu
@@ -24,10 +24,49 @@ __global__ void vector_add_sr_kernel(T* dest, const T* left, const T* right, flo
 }
 
 template<typename T>
+__global__ void vector_reduce_sr_kernel(T* dest, const T* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed) {
+    using vecx_t = GenericVector<T, 16/sizeof(T)>;
+    using vecf_t = GenericVector<float, 16/sizeof(T)>;
+    long idx = (blockIdx.x * blockDim.x + threadIdx.x) * vecx_t::size;
+
+    if(idx < nelem) {
+        vecf_t accumulator = vecf_t::zeros();
+        if(accumulate) {
+            vecx_t v = vecx_t::load_cs(dest + idx);
+            for(int j = 0; j < vecx_t::size; ++j) {
+                accumulator[j] += (float) v[j];
+            }
+        }
+        for (int k = 0; k < n_shards; ++k) {
+            if(k == skip) continue;
+            vecx_t v = vecx_t::load_cs(src + idx + k * nelem);
+            for(int j = 0; j < vecx_t::size; ++j) {
+                accumulator[j] += (float) v[j];
+            }
+        }
+
+        vecx_t result;
+        for(int j = 0; j < vecx_t::size; ++j) {
+            float sum = scale * accumulator[j];
+            stochastic_rounding(sum, &result[j], seed + idx);
+        }
+        result.store(dest + idx);
+    }
+}
+
+template<typename T>
 void vector_add_sr_imp(T* dest, const T* left, const T* right, float scale, long nelem, unsigned seed, cudaStream_t stream) {
     long block_size = 512;
     long grid_size = div_ceil(nelem, block_size);
     vector_add_sr_kernel<T><<<grid_size, block_size, 0, stream>>>(dest, left, right, scale, nelem, seed);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+template<typename T>
+void vector_reduce_sr_imp(T* dest, const T* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream) {
+    long block_size = 512;
+    long grid_size = div_ceil(nelem, block_size);
+    vector_reduce_sr_kernel<T><<<grid_size, block_size, 0, stream>>>(dest, src, scale, n_shards, skip, nelem, accumulate, seed);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -37,4 +76,12 @@ void vector_add_sr(float* dest, const float* left, const float* right, float sca
 
 void vector_add_sr(nv_bfloat16* dest, const nv_bfloat16* left, const nv_bfloat16* right, float scale, long nelem, unsigned seed, cudaStream_t stream) {
     vector_add_sr_imp(dest, left, right, scale, nelem, seed, stream);
+}
+
+void vector_reduce_sr(float* dest, const float* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream) {
+    vector_reduce_sr_imp(dest, src, scale, n_shards, skip, nelem, accumulate, seed, stream);
+}
+
+void vector_reduce_sr(nv_bfloat16* dest, const nv_bfloat16* src, float scale, int n_shards, int skip, long nelem, bool accumulate, unsigned seed, cudaStream_t stream) {
+    vector_reduce_sr_imp(dest, src, scale, n_shards, skip, nelem, accumulate, seed, stream);
 }

--- a/src/models/llama_gradients.cpp
+++ b/src/models/llama_gradients.cpp
@@ -448,26 +448,22 @@ void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_layer(int layer_idx,
 
     int rank = comm.rank();
     int world = comm.world_size();
+    float scale = 1.f;
+    if (mIsLastMicroStep) {
+        scale = 1.f / world;
+    }
 
-    for (int k = 0; k < world - 1; ++k) {
-        int other = (rank + k) % world;
-        float scale = 1.f;
-        if (k == world - 2 && mIsLastMicroStep) {
-            scale = 1.f / world;
-        }
+    auto rng_1 = mRng.generate(2*mStepCounter + 0, layer_idx);
+    auto rng_2 = mRng.generate(2*mStepCounter + 1, layer_idx + 12345);
 
-        auto rng_1 = mRng.generate(2*mStepCounter + 0, layer_idx + 12345*k);
-        auto rng_2 = mRng.generate(2*mStepCounter + 1, layer_idx + 12345+k + 1);
-
-        sr_accumulate_tensor(sw.LN1_w, dw.LN1_w, stream, false, scale, other, rng_1[0]);
-        sr_accumulate_tensor(sw.LN2_w, dw.LN2_w, stream, false, scale, other, rng_1[1]);
-        sr_accumulate_tensor(sw.MLP_Up_w, dw.MLP_Up_w, stream, false, scale, other, rng_1[2]);
-        sr_accumulate_tensor(sw.MLP_Down_w, dw.MLP_Down_w, stream, false, scale, other, rng_1[3]);
-        sr_accumulate_tensor(sw.Attn_QKV_w, dw.Attn_QKV_w, stream, false, scale, other, rng_2[0]);
-        sr_accumulate_tensor(sw.Attn_Out_w, dw.Attn_Out_w, stream, false, scale, other, rng_2[1]);
-        if(sw.Attn_QKV_b.has_value()) {
-            sr_accumulate_tensor(sw.Attn_QKV_b.value(), dw.Attn_QKV_b.value(), stream, false, scale, other, rng_2[2]);
-        }
+    vector_reduce_sr(sw.LN1_w, dw.LN1_w, scale, world, (rank + world - 1) % world, sw.LN1_w.nelem(), true, rng_1[0], stream);
+    vector_reduce_sr(sw.LN2_w, dw.LN2_w, scale, world, (rank + world - 1) % world, sw.LN2_w.nelem(), true, rng_1[1], stream);
+    vector_reduce_sr(sw.MLP_Up_w, dw.MLP_Up_w, scale, world, (rank + world - 1) % world, sw.MLP_Up_w.nelem(), true, rng_1[2], stream);
+    vector_reduce_sr(sw.MLP_Down_w, dw.MLP_Down_w, scale, world, (rank + world - 1) % world, sw.MLP_Down_w.nelem(), true, rng_1[3], stream);
+    vector_reduce_sr(sw.Attn_QKV_w, dw.Attn_QKV_w, scale, world, (rank + world - 1) % world, sw.Attn_QKV_w.nelem(), true, rng_2[0], stream);
+    vector_reduce_sr(sw.Attn_Out_w, dw.Attn_Out_w, scale, world, (rank + world - 1) % world, sw.Attn_Out_w.nelem(), true, rng_2[1], stream);
+    if(sw.Attn_QKV_b.has_value()) {
+        vector_reduce_sr(sw.Attn_QKV_b.value(), dw.Attn_QKV_b.value(), scale, world, (rank + world - 1) % world, sw.Attn_QKV_b->nelem(), true, rng_2[2], stream);
     }
 }
 


### PR DESCRIPTION
Uses a single n-way reduction kernel, instead of multiple two-way reductions. Reduces the amount of roundings, and of memory round trips