### PR TITLE
Generic tensor collection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(llmq-common SHARED
         src/utilities/dtype.cpp
         src/utilities/stack.cpp
 
+        src/training/adamw_optimizer.cpp
         src/training/dataloader.cpp
         src/training/logging.cpp
         src/training/checkpoint.cpp

--- a/src/binding/py_train.cpp
+++ b/src/binding/py_train.cpp
@@ -279,16 +279,17 @@ std::vector<std::pair<std::string, Tensor>> MultiGPUPyTrainer::get_gradients(int
         }
         result.emplace_back("model.norm.weight", grads.get_lnf_w_shard(nullptr));
         for (int l = 0; l < config.NumLayers; l++) {
+            using namespace LLamaWeightID;
             std::string prefix = "model.layers." + std::to_string(l);
             auto& block = grads.get_block_shard(l, nullptr);
-            result.emplace_back(prefix + ".self_attn.qkv.weight", block.Attn_QKV_w);
-            if (block.Attn_QKV_b)
-                result.emplace_back(prefix + ".self_attn.qkv.bias", block.Attn_QKV_b);
-            result.emplace_back(prefix + ".self_attn.o_proj.weight", block.Attn_Out_w);
-            result.emplace_back(prefix + ".mlp.up.weight", block.MLP_Up_w);
-            result.emplace_back(prefix + ".mlp.down_proj.weight", block.MLP_Down_w);
-            result.emplace_back(prefix + ".input_layernorm.weight", block.LN1_w);
-            result.emplace_back(prefix + ".post_attention_layernorm.weight", block.LN2_w);
+            result.emplace_back(prefix + ".self_attn.qkv.weight", block.get_tensor(QKV_W));
+            if (block.get_tensor(QKV_B))
+                result.emplace_back(prefix + ".self_attn.qkv.bias", block.get_tensor(QKV_B));
+            result.emplace_back(prefix + ".self_attn.o_proj.weight", block.get_tensor(ATTO_W));
+            result.emplace_back(prefix + ".mlp.up.weight", block.get_tensor(UP_W));
+            result.emplace_back(prefix + ".mlp.down_proj.weight", block.get_tensor(DOWN_W));
+            result.emplace_back(prefix + ".input_layernorm.weight", block.get_tensor(LN1_W));
+            result.emplace_back(prefix + ".post_attention_layernorm.weight", block.get_tensor(LN2_W));
         }
         CUDA_CHECK(cudaDeviceSynchronize());
     }, gpu_id);

--- a/src/models/llama_gradients.cpp
+++ b/src/models/llama_gradients.cpp
@@ -18,15 +18,9 @@ void LLamaGradsManager::scatter_reduce(Tensor& tensor, cudaStream_t stream, cuda
     comm.execute_transaction(signal);
 }
 
-void LLamaGradsManager::scatter_reduce(int layer_idx, sLLamaBlockWeights<Tensor>& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) {
+void LLamaGradsManager::scatter_reduce(int layer_idx, SimpleTensorContainer& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) {
     comm.begin_transaction(stream);
-    comm.schedule_reduce_scatter(block.LN1_w);
-    comm.schedule_reduce_scatter(block.Attn_QKV_w);
-    comm.schedule_reduce_scatter(block.Attn_Out_w);
-    comm.schedule_reduce_scatter(block.LN2_w);
-    comm.schedule_reduce_scatter(block.MLP_Up_w);
-    comm.schedule_reduce_scatter(block.MLP_Down_w);
-    comm.schedule_reduce_scatter(block.Attn_QKV_b);
+    visit([&](Tensor& t){ comm.schedule_reduce_scatter(t); }, block);
     comm.execute_transaction(signal);
 }
 
@@ -192,8 +186,8 @@ public:
     sLLamaBlockWeights<TensorShard>& get_block_shard(int layer_idx, cudaStream_t stream) override;
 private:
     virtual void sr_accumulate_layer(int layer_idx,
-                                     sLLamaBlockWeights<Tensor>& dw,
-                                     sLLamaBlockWeights<TensorShard> sw,
+                                     SimpleTensorContainer& dw,
+                                     SimpleTensorContainer& sw,
                                      cudaStream_t stream,
                                      NCCLCommunicator& comm) = 0;
 
@@ -341,41 +335,35 @@ class LLamaGradientsBlockSharded_ScatterReduce : public LLamaGradientsBlockShard
 public:
     using LLamaGradientsBlockShardedBase::LLamaGradientsBlockShardedBase;
 private:
-    void sr_accumulate_tensor(TensorShard& dst, Tensor& src, cudaStream_t stream, unsigned seed);
     void sr_accumulate_layer(int layer_idx,
-                             sLLamaBlockWeights<Tensor>& dw,
-                             sLLamaBlockWeights<TensorShard> sw,
+                             SimpleTensorContainer& dw,
+                             SimpleTensorContainer& sw,
                              cudaStream_t stream,
                              NCCLCommunicator& comm) override;
 };
 
-void LLamaGradientsBlockSharded_ScatterReduce::sr_accumulate_tensor(TensorShard& dst, Tensor& src, cudaStream_t stream, unsigned seed) {
-    Tensor local_slice = shard_view(src, dst.ShardIndex, dst.NumShards);
-    if(mIsFirstMicroStep) {
-        CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
-    } else {
-        vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), seed, stream);
-    }
-}
-
 void LLamaGradientsBlockSharded_ScatterReduce::sr_accumulate_layer(int layer_idx,
-                                                                   sLLamaBlockWeights<Tensor>& dw,
-                                                                   sLLamaBlockWeights<TensorShard> sw,
+                                                                   SimpleTensorContainer& dw,
+                                                                   SimpleTensorContainer& sw,
                                                                    cudaStream_t stream,
                                                                    NCCLCommunicator& comm) {
     NvtxRange range("accumulate_layer", layer_idx);
     std::array<std::uint32_t, 8> rng;
     mRng.generate(std::span(rng), 2*mStepCounter, layer_idx);
 
-    sr_accumulate_tensor(sw.LN1_w, dw.LN1_w, stream, rng[0]);
-    sr_accumulate_tensor(sw.LN2_w, dw.LN2_w, stream, rng[1]);
-    sr_accumulate_tensor(sw.MLP_Up_w, dw.MLP_Up_w, stream, rng[2]);
-    sr_accumulate_tensor(sw.MLP_Down_w, dw.MLP_Down_w, stream, rng[3]);
-    sr_accumulate_tensor(sw.Attn_QKV_w, dw.Attn_QKV_w, stream, rng[4]);
-    sr_accumulate_tensor(sw.Attn_Out_w, dw.Attn_Out_w, stream, rng[5]);
-    if(sw.Attn_QKV_b) {
-        sr_accumulate_tensor(sw.Attn_QKV_b, dw.Attn_QKV_b, stream, rng[6]);
-    }
+    int rank = comm.rank();
+    int world = comm.world_size();
+
+    int i = 0;
+    visit([&](Tensor& dst, Tensor& src){
+        Tensor local_slice = shard_view(src, rank, world);
+        if(mIsFirstMicroStep) {
+            CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
+        } else {
+            vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng[i], stream);
+        }
+        ++i;
+    }, sw, dw);
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -384,33 +372,34 @@ class LLamaGradientsBlockSharded_AllToAll : public LLamaGradientsBlockShardedBas
 public:
     using LLamaGradientsBlockShardedBase::LLamaGradientsBlockShardedBase;
 private:
-    void scatter_reduce(int layer_idx, sLLamaBlockWeights<Tensor>& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) override;
-    void sr_accumulate_tensor(TensorShard& dst, Tensor& src, cudaStream_t stream, bool first, float scale, int shard, unsigned seed);
+    void scatter_reduce(int layer_idx, SimpleTensorContainer& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) override;
     void sr_accumulate_layer(int layer_idx,
-                             sLLamaBlockWeights<Tensor>& dw,
-                             sLLamaBlockWeights<TensorShard> sw,
+                             SimpleTensorContainer& dw,
+                             SimpleTensorContainer& sw,
                              cudaStream_t stream,
                              NCCLCommunicator& comm) override;
 };
 
-void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, sLLamaBlockWeights<Tensor>& dw, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) {
+void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, SimpleTensorContainer& dw, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) {
     auto& sw = get_block_shard(layer_idx, stream);
     int rank = sw.LN1_w.ShardIndex;
+    int world = sw.LN1_w.NumShards;
 
     // accumulate local slice of block to local gradient
     {
         NvtxRange range("accumulate-own-shard", layer_idx);
         std::array<std::uint32_t, 8> rng;
         mRng.generate(std::span(rng), 2*mStepCounter, layer_idx);
-        sr_accumulate_tensor(sw.LN1_w, dw.LN1_w, stream, mIsFirstMicroStep, 1.f, rank, rng[0]);
-        sr_accumulate_tensor(sw.LN2_w, dw.LN2_w, stream, mIsFirstMicroStep, 1.f, rank, rng[1]);
-        sr_accumulate_tensor(sw.Attn_QKV_w, dw.Attn_QKV_w, stream, mIsFirstMicroStep, 1.f, rank, rng[2]);
-        sr_accumulate_tensor(sw.Attn_Out_w, dw.Attn_Out_w, stream, mIsFirstMicroStep, 1.f, rank, rng[3]);
-        sr_accumulate_tensor(sw.MLP_Up_w, dw.MLP_Up_w, stream, mIsFirstMicroStep, 1.f, rank, rng[4]);
-        sr_accumulate_tensor(sw.MLP_Down_w, dw.MLP_Down_w, stream, mIsFirstMicroStep, 1.f, rank, rng[5]);
-        if (sw.Attn_QKV_b) {
-            sr_accumulate_tensor(sw.Attn_QKV_b, dw.Attn_QKV_b, stream, mIsFirstMicroStep, 1.f, rank, rng[6]);
-        }
+        int i = 0;
+        visit([&](Tensor& dst, Tensor& src){
+            Tensor local_slice = shard_view(src, rank, world);
+            if(mIsFirstMicroStep) {
+                CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
+            } else {
+                vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng[i], stream);
+            }
+            ++i;
+        }, sw, dw);
     }
 
     // make sure we've done the local accumulation before we allow communication to begin.
@@ -419,30 +408,15 @@ void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, sLLamaBl
     NvtxRange range("all-to-all-gradients", layer_idx);
 
     comm.begin_transaction(signal);
-    comm.schedule_destructive_all_to_all(dw.LN1_w);
-    comm.schedule_destructive_all_to_all(dw.Attn_QKV_w);
-    comm.schedule_destructive_all_to_all(dw.Attn_Out_w);
-    comm.schedule_destructive_all_to_all(dw.LN2_w);
-    comm.schedule_destructive_all_to_all(dw.MLP_Up_w);
-    comm.schedule_destructive_all_to_all(dw.MLP_Down_w);
-    comm.schedule_destructive_all_to_all(dw.Attn_QKV_b);
+    visit([&](Tensor& t){ comm.schedule_reduce_scatter(t); }, dw);
     comm.execute_transaction(signal);
 }
 
-void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_tensor(TensorShard& dst, Tensor& src, cudaStream_t stream, bool first, float scale, int shard, unsigned seed) {
-    Tensor local_slice = shard_view(src, shard, dst.NumShards);
-    if(first) {
-        CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
-    } else {
-        vector_add_sr(dst, dst, local_slice, scale, local_slice.nelem(), seed, stream);
-    }
-}
-
 void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_layer(int layer_idx,
-                                                 sLLamaBlockWeights<Tensor>& dw,
-                                                 sLLamaBlockWeights<TensorShard> sw,
-                                                 cudaStream_t stream,
-                                                 NCCLCommunicator& comm) {
+                                                              SimpleTensorContainer& dw,
+                                                              SimpleTensorContainer& sw,
+                                                              cudaStream_t stream,
+                                                              NCCLCommunicator& comm) {
     NvtxRange range("accumulate_layer", layer_idx);
 
     int rank = comm.rank();
@@ -455,15 +429,11 @@ void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_layer(int layer_idx,
     std::array<std::uint32_t, 8> rng;
     mRng.generate(std::span(rng), 2*mStepCounter, layer_idx);
 
-    vector_reduce_sr(sw.LN1_w, dw.LN1_w, scale, world, (rank + world - 1) % world, sw.LN1_w.nelem(), true, rng[0], stream);
-    vector_reduce_sr(sw.LN2_w, dw.LN2_w, scale, world, (rank + world - 1) % world, sw.LN2_w.nelem(), true, rng[1], stream);
-    vector_reduce_sr(sw.MLP_Up_w, dw.MLP_Up_w, scale, world, (rank + world - 1) % world, sw.MLP_Up_w.nelem(), true, rng[2], stream);
-    vector_reduce_sr(sw.MLP_Down_w, dw.MLP_Down_w, scale, world, (rank + world - 1) % world, sw.MLP_Down_w.nelem(), true, rng[3], stream);
-    vector_reduce_sr(sw.Attn_QKV_w, dw.Attn_QKV_w, scale, world, (rank + world - 1) % world, sw.Attn_QKV_w.nelem(), true, rng[4], stream);
-    vector_reduce_sr(sw.Attn_Out_w, dw.Attn_Out_w, scale, world, (rank + world - 1) % world, sw.Attn_Out_w.nelem(), true, rng[5], stream);
-    if(sw.Attn_QKV_b) {
-        vector_reduce_sr(sw.Attn_QKV_b, dw.Attn_QKV_b, scale, world, (rank + world - 1) % world, sw.Attn_QKV_b.nelem(), true, rng[6], stream);
-    }
+    int i = 0;
+    visit([&](Tensor& s, Tensor& d){
+        vector_reduce_sr(s, d, scale, world, (rank + world - 1) % world, s.nelem(), true, rng[i], stream);
+        ++i;
+    }, sw, dw);
 }
 
 std::unique_ptr<LLamaGradsManager> LLamaGradsManager::create(std::uint64_t seed, int step, const TransformerConfig& config, const LLamaOptions& options, int rank, int world, const std::shared_ptr<TensorAllocator>& alloc) {

--- a/src/models/llama_gradients.cpp
+++ b/src/models/llama_gradients.cpp
@@ -360,7 +360,7 @@ void LLamaGradientsBlockSharded_ScatterReduce::sr_accumulate_layer(int layer_idx
         if(mIsFirstMicroStep) {
             CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
         } else {
-            vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng[i], stream);
+            vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng.at(i), stream);
         }
         ++i;
     }, sw, dw);
@@ -382,8 +382,8 @@ private:
 
 void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, SimpleTensorContainer& dw, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm) {
     auto& sw = get_block_shard(layer_idx, stream);
-    int rank = sw.LN1_w.ShardIndex;
-    int world = sw.LN1_w.NumShards;
+    int rank = comm.rank();
+    int world = comm.world_size();
 
     // accumulate local slice of block to local gradient
     {
@@ -396,7 +396,7 @@ void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, SimpleTe
             if(mIsFirstMicroStep) {
                 CUDA_CHECK(cudaMemcpyAsync(dst.Data, local_slice.Data, local_slice.bytes(), cudaMemcpyDeviceToDevice, stream));
             } else {
-                vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng[i], stream);
+                vector_add_sr(dst, dst, local_slice, 1.f, local_slice.nelem(), rng.at(i), stream);
             }
             ++i;
         }, sw, dw);
@@ -408,7 +408,7 @@ void LLamaGradientsBlockSharded_AllToAll::scatter_reduce(int layer_idx, SimpleTe
     NvtxRange range("all-to-all-gradients", layer_idx);
 
     comm.begin_transaction(signal);
-    visit([&](Tensor& t){ comm.schedule_reduce_scatter(t); }, dw);
+    visit([&](Tensor& t){ comm.schedule_destructive_all_to_all(t); }, dw);
     comm.execute_transaction(signal);
 }
 
@@ -431,7 +431,7 @@ void LLamaGradientsBlockSharded_AllToAll::sr_accumulate_layer(int layer_idx,
 
     int i = 0;
     visit([&](Tensor& s, Tensor& d){
-        vector_reduce_sr(s, d, scale, world, (rank + world - 1) % world, s.nelem(), true, rng[i], stream);
+        vector_reduce_sr(s, d, scale, world, (rank + world - 1) % world, s.nelem(), true, rng.at(i), stream);
         ++i;
     }, sw, dw);
 }

--- a/src/models/llama_gradients.h
+++ b/src/models/llama_gradients.h
@@ -42,7 +42,7 @@ protected:
     virtual void on_first_micro_step(cudaStream_t stream) = 0;
 
     void scatter_reduce(Tensor& tensor, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm);
-    virtual void scatter_reduce(int layer_idx, sLLamaBlockWeights<Tensor>& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm);
+    virtual void scatter_reduce(int layer_idx, SimpleTensorContainer& block, cudaStream_t stream, cudaEvent_t signal, NCCLCommunicator& comm);
 
     Philox4x32 mRng;
     int mStepCounter = -1;

--- a/src/models/llama_gradients.h
+++ b/src/models/llama_gradients.h
@@ -25,7 +25,7 @@ public:
     virtual TensorShard& get_embeddings_shard(cudaStream_t stream) = 0;
     virtual TensorShard& get_lmhead_shard(cudaStream_t stream) = 0;
     virtual TensorShard& get_lnf_w_shard(cudaStream_t stream) = 0;
-    virtual sLLamaBlockWeights<TensorShard>& get_block_shard(int layer_idx, cudaStream_t stream) = 0;
+    virtual SimpleTensorContainer& get_block_shard(int layer_idx, cudaStream_t stream) = 0;
 
     // notify that gradient calculations have been completed
     virtual void notify_embeddings(cudaStream_t stream, NCCLCommunicator& comm) = 0;

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -708,15 +708,9 @@ void LLamaModel::_calculate_gradient_norm(NCCLCommunicator& comm, float grad_cli
 
     for(int i = 0; i < Config.NumLayers; i++) {
         auto& block = Grads->get_block_shard(i, stream);
-        norm_squared(block.LN1_w);
-        norm_squared(block.LN2_w);
-        norm_squared(block.Attn_QKV_w);
-        if(block.Attn_QKV_b) {
-            norm_squared(block.Attn_QKV_b);
-        }
-        norm_squared(block.Attn_Out_w);
-        norm_squared(block.MLP_Up_w);
-        norm_squared(block.MLP_Down_w);
+        visit([&](Tensor& t){
+            norm_squared(t);
+        }, block);
     }
 
     // final reduction to a single norm-squared element

--- a/src/models/llama_model.cpp
+++ b/src/models/llama_model.cpp
@@ -761,6 +761,7 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
     CUDA_CHECK(cudaEventRecord(rs->OptEmbeddingsDone, main_stream));
 
     for(int i = 0; i < Config.NumLayers; i++) {
+        using namespace LLamaWeightID;
         NvtxRange layer_range("Layer", i);
         Parameters->fetch_master_block(i, comm.stream());
         OptimizerState->fetch_block(i, comm.stream());
@@ -768,19 +769,19 @@ void LLamaModel::update(NCCLCommunicator& comm, float learning_rate, float beta_
         auto& bg = Grads->get_block_shard(i, main_stream);
         auto& bm = OptimizerState->get_block_m(i, main_stream);
         auto& bv = OptimizerState->get_block_v(i, main_stream);
-        auto& sm = m_scales.Blocks[i];
-        run_update(bw.LN1_w, bg.LN1_w, bm.LN1_w, bv.LN1_w, sm.LN1_w, 0.f);
-        run_update(bw.LN2_w, bg.LN2_w, bm.LN2_w, bv.LN2_w, sm.LN2_w, 0.f);
+        auto& sm = OptimizerState->get_block_scales_m(i);
+        run_update(bw.get_tensor(LN1_W), bg.get_tensor(LN1_W), bm.get_tensor(LN1_W), bv.get_tensor(LN1_W), sm.get_tensor(LN1_W), 0.f);
+        run_update(bw.get_tensor(LN2_W), bg.get_tensor(LN2_W), bm.get_tensor(LN2_W), bv.get_tensor(LN2_W), sm.get_tensor(LN2_W), 0.f);
 
-        run_update(bw.Attn_QKV_w, bg.Attn_QKV_w, bm.Attn_QKV_w, bv.Attn_QKV_w,
-                   sm.Attn_QKV_w, weight_decay);
-        if(bm.Attn_QKV_b) {
-            run_update(bw.Attn_QKV_b, bg.Attn_QKV_b, bm.Attn_QKV_b, bv.Attn_QKV_b, sm.Attn_QKV_b, 0.f);
+        run_update(bw.get_tensor(QKV_W), bg.get_tensor(QKV_W), bm.get_tensor(QKV_W), bv.get_tensor(QKV_W),
+                   sm.get_tensor(QKV_W), weight_decay);
+        if(Config.UseQKVBias) {
+            run_update(bw.get_tensor(QKV_B), bg.get_tensor(QKV_B), bm.get_tensor(QKV_B), bv.get_tensor(QKV_B), sm.get_tensor(QKV_B), 0.f);
         }
-        run_update(bw.Attn_Out_w, bg.Attn_Out_w, bm.Attn_Out_w, bv.Attn_Out_w, sm.Attn_Out_w, weight_decay);
+        run_update(bw.get_tensor(ATTO_W), bg.get_tensor(ATTO_W), bm.get_tensor(ATTO_W), bv.get_tensor(ATTO_W), sm.get_tensor(ATTO_W), weight_decay);
 
-        run_update(bw.MLP_Up_w, bg.MLP_Up_w, bm.MLP_Up_w, bv.MLP_Up_w, sm.MLP_Up_w, weight_decay);
-        run_update(bw.MLP_Down_w, bg.MLP_Down_w, bm.MLP_Down_w, bv.MLP_Down_w, sm.MLP_Down_w, weight_decay);
+        run_update(bw.get_tensor(UP_W), bg.get_tensor(UP_W), bm.get_tensor(UP_W), bv.get_tensor(UP_W), sm.get_tensor(UP_W), weight_decay);
+        run_update(bw.get_tensor(DOWN_W), bg.get_tensor(DOWN_W), bm.get_tensor(DOWN_W), bv.get_tensor(DOWN_W), sm.get_tensor(DOWN_W), weight_decay);
         auto scales = Parameters->get_scales_for_block(i);
         // yes, we run this on main stream. Yes, this isn't nice because it prevents kernels from running in parallel.
         // the communication is tiny, though, so it doesn't matter, and this setup guarantees that the abs-maxes are

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -85,12 +85,12 @@ void LLamaOptimizerStateManager::end_optimizer(DeviceMemoryStack& memory) {
     }
 }
 
-sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_m(int layer_idx, cudaStream_t stream) {
+SimpleTensorContainer& LLamaOptimizerStateManager::get_block_m(int layer_idx, cudaStream_t stream) {
     if(!mOffloadM || mUseZeroCopy) return mOptM.Blocks[layer_idx];
     return get_block_from(layer_idx, stream, mOptMBuffer.at(layer_idx % 2));
 }
 
-sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_v(int layer_idx, cudaStream_t stream) {
+SimpleTensorContainer& LLamaOptimizerStateManager::get_block_v(int layer_idx, cudaStream_t stream) {
     if(!mOffloadV || mUseZeroCopy) return mOptV.Blocks[layer_idx];
     return get_block_from(layer_idx, stream, mOptVBuffer.at(layer_idx % 2));
 }
@@ -213,7 +213,7 @@ std::vector<Tensor> allocate_weights_opt(sLLamaWeights& weights, const Transform
 
 
 LLamaOptimizerStateManager::LLamaOptimizerStateManager(TransformerConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc):
-    mOffloadM(options.OffloadOptM), mOffloadV(options.OffloadOptV), mUseZeroCopy(options.UseZeroCopy), mConfig(cfg), mRank(comm.rank()), mWorld(comm.world_size())
+        AdamWStateManager(cfg, options.OffloadOptM, options.OffloadOptV, options.UseZeroCopy, comm.rank(), comm.world_size())
 {
     {
         auto ctx = alloc.with_context("Adam M");
@@ -245,4 +245,8 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(TransformerConfig cfg, LL
         mStatus[0] = sBufferStatus{-1, create_named_event("opt_fetch_0"), false, true};
         mStatus[1] = sBufferStatus{-1, create_named_event("opt_fetch_1"), false, true};
     }
+}
+
+SimpleTensorContainer &LLamaOptimizerStateManager::get_block_scales_m(int layer_idx) {
+    return mOptMScales.Blocks.at(layer_idx);
 }

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -177,17 +177,13 @@ sLLamaWeights allocate_scales(TransformerConfig config, int shard_idx, int num_s
         block.LN2_w = alloc.allocate_shard(ETensorDType::FP32, shard_idx, num_shards, "ln2_w", {div_exact(C, 128l)}, EAllocationType::ON_DEVICE);
         if(config.UseQKVBias) {
             block.Attn_QKV_b = alloc.allocate_shard(ETensorDType::FP32, shard_idx, num_shards, "att_qkv_b", {div_exact(attn_intermediate_size, 128l)}, EAllocationType::ON_DEVICE);
-            fill_constant(block.Attn_QKV_b, 1.f, block.Attn_QKV_b.nelem(), nullptr);
         } else {
             block.Attn_QKV_b = Tensor{};
         }
 
-        fill_constant(block.Attn_QKV_w, 1.f, block.Attn_QKV_w.nelem(), nullptr);
-        fill_constant(block.Attn_Out_w, 1.f, block.Attn_Out_w.nelem(), nullptr);
-        fill_constant(block.MLP_Up_w, 1.f, block.MLP_Up_w.nelem(), nullptr);
-        fill_constant(block.MLP_Down_w, 1.f, block.MLP_Down_w.nelem(), nullptr);
-        fill_constant(block.LN1_w, 1.f, block.LN1_w.nelem(), nullptr);
-        fill_constant(block.LN2_w, 1.f, block.LN2_w.nelem(), nullptr);
+        visit([](Tensor& t){
+            fill_constant(t, 1.f, t.nelem(), nullptr);
+        }, block);
     }
     result.NonBlocks.Embeddings = alloc.allocate_shard(ETensorDType::FP32, shard_idx, num_shards, "embeddings", {div_exact(V * C, 128l)}, EAllocationType::ON_DEVICE);
     result.NonBlocks.LNF_w      = alloc.allocate_shard(ETensorDType::FP32, shard_idx, num_shards,"lnf_w", {div_exact(C, 128l)}, EAllocationType::ON_DEVICE);

--- a/src/models/llama_optimizer.cpp
+++ b/src/models/llama_optimizer.cpp
@@ -4,45 +4,12 @@
 
 
 #include "llama_optimizer.h"
-#include "../training/transformer_config.h"
+#include "training/transformer_config.h"
 #include "llama_model.h"
 #include "utilities/comm.h"
 #include "kernels/kernels.h"
 #include "utilities/stack.h"
 #include "utilities/lazy_allocator.h"
-
-void LLamaOptimizerStateManager::fetch_block(int layer_idx, cudaStream_t fetch_stream) {
-    if((!mOffloadM && !mOffloadV) || mUseZeroCopy) return;
-
-    NvtxRange range("fetch_opt_block", layer_idx);
-    int buffer = layer_idx % 2;
-    auto& stat = mStatus.at(buffer);
-    stat.LayerIdx = layer_idx;
-    stat.Fetch = true;
-
-    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, stat.DoneEvent, 0));
-
-    auto fetch = [fetch_stream, &stat](Tensor& dst, Tensor& src) {
-        CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyHostToDevice, fetch_stream));
-        dst.Stats = src.Stats;
-    };
-
-    if(mOffloadM) {
-        auto& buf = mOptMBufferStorage.at(buffer);
-        auto& ref = mOptMBlockStorage.at(layer_idx);
-
-        fetch(buf, ref);
-    }
-
-    if(mOffloadV) {
-        auto& buf = mOptVBufferStorage.at(buffer);
-        auto& ref = mOptVBlockStorage.at(layer_idx);
-
-        fetch(buf, ref);
-    }
-
-    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
-}
 
 void LLamaOptimizerStateManager::begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream) {
     LazyAllocator alloc;
@@ -56,32 +23,21 @@ void LLamaOptimizerStateManager::begin_optimizer(DeviceMemoryStack& memory, cuda
         ETensorDType m_type = mOptM.Blocks[0].LN1_w.DType;
         matrix_params_lazy(mOptMBuffer[0], mConfig, m_type, mRank, mWorld, alloc);
         non_matrix_params_lazy(mOptMBuffer[0], mConfig, m_type, mRank, mWorld, alloc);
-        mOptMBufferStorage[0] = alloc.commit(memory, "opt_m_a");
+        mMBufferStorage[0] = alloc.commit(memory, "opt_m_a");
         matrix_params_lazy(mOptMBuffer[1], mConfig, m_type, mRank, mWorld, alloc);
         non_matrix_params_lazy(mOptMBuffer[1], mConfig, m_type, mRank, mWorld, alloc);
-        mOptMBufferStorage[1] = alloc.commit(memory, "opt_m_b");
+        mMBufferStorage[1] = alloc.commit(memory, "opt_m_b");
     }
 
     if(mOffloadV &&! mUseZeroCopy) {
         ETensorDType v_type = mOptV.Blocks[0].LN1_w.DType;
         matrix_params_lazy(mOptVBuffer[0], mConfig, v_type, mRank, mWorld, alloc);
         non_matrix_params_lazy(mOptVBuffer[0], mConfig, v_type, mRank, mWorld, alloc);
-        mOptVBufferStorage[0] = alloc.commit(memory, "opt_v_a");
+        mVBufferStorage[0] = alloc.commit(memory, "opt_v_a");
         matrix_params_lazy(mOptVBuffer[1], mConfig, v_type, mRank, mWorld, alloc);
         non_matrix_params_lazy(mOptVBuffer[1], mConfig, v_type, mRank, mWorld, alloc);
-        mOptVBufferStorage[1] = alloc.commit(memory, "opt_v_b");
+        mVBufferStorage[1] = alloc.commit(memory, "opt_v_b");
 
-    }
-}
-void LLamaOptimizerStateManager::end_optimizer(DeviceMemoryStack& memory) {
-    if(mOffloadV &&! mUseZeroCopy) {
-        memory.free(mOptVBufferStorage[1]);
-        memory.free(mOptVBufferStorage[0]);
-    }
-
-    if(mOffloadM &&! mUseZeroCopy) {
-        memory.free(mOptMBufferStorage[1]);
-        memory.free(mOptMBufferStorage[0]);
     }
 }
 
@@ -93,52 +49,6 @@ SimpleTensorContainer& LLamaOptimizerStateManager::get_block_m(int layer_idx, cu
 SimpleTensorContainer& LLamaOptimizerStateManager::get_block_v(int layer_idx, cudaStream_t stream) {
     if(!mOffloadV || mUseZeroCopy) return mOptV.Blocks[layer_idx];
     return get_block_from(layer_idx, stream, mOptVBuffer.at(layer_idx % 2));
-}
-
-sLLamaBlockWeights<TensorShard>& LLamaOptimizerStateManager::get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf) {
-    int buffer = layer_idx % 2;
-    auto& stat = mStatus.at(buffer);
-
-    if(stat.LayerIdx != layer_idx) {
-        throw std::logic_error("Layer index mismatch in get_block_from");
-    }
-
-    stat.Done = false;
-    // if we needed to fetch, we need to wait
-    if(stat.Fetch) {
-        CUDA_CHECK(cudaStreamWaitEvent(stream, stat.DoneEvent, 0));
-    }
-    stat.Fetch = false;
-
-    return buf;
-}
-
-void LLamaOptimizerStateManager::store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream)  {
-    if (mUseZeroCopy) return;
-
-    NvtxRange range("store_opt_block", layer_idx);
-    int buffer = layer_idx % 2;
-    auto& stat = mStatus.at(layer_idx % 2);
-    if(mOffloadM || mOffloadV) {
-        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
-        CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
-    }
-
-    if(mOffloadM) {
-        CUDA_CHECK(cudaMemcpyAsync(mOptMBlockStorage.at(layer_idx).Data, mOptMBufferStorage.at(buffer).Data, mOptMBlockStorage.at(layer_idx).bytes(), cudaMemcpyDeviceToHost, put_stream));
-    }
-
-    if(mOffloadV) {
-        CUDA_CHECK(cudaMemcpyAsync(mOptVBlockStorage.at(layer_idx).Data, mOptVBufferStorage.at(buffer).Data, mOptVBlockStorage.at(layer_idx).bytes(), cudaMemcpyDeviceToHost, put_stream));
-    }
-
-    if(mOffloadM || mOffloadV) {
-        if(stat.LayerIdx != layer_idx) {
-            throw std::logic_error("layer index mismatch in store_block");
-        }
-        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, put_stream));
-        stat.Done = true;
-    }
 }
 
 sLLamaNonBlockWeights<TensorShard>& LLamaOptimizerStateManager::non_block_m() {
@@ -218,8 +128,8 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(TransformerConfig cfg, LL
     {
         auto ctx = alloc.with_context("Adam M");
         EAllocationType alloc_type = options.OffloadOptM ? options.offload_alloc() : EAllocationType::ON_DEVICE;
-        mOptMBlockStorage = allocate_weights_opt(mOptM, cfg, options.OptMomentumType, alloc_type, comm.rank(), comm.world_size(), alloc);
-        for(auto& block : mOptMBlockStorage) {
+        mMBlockStorage = allocate_weights_opt(mOptM, cfg, options.OptMomentumType, alloc_type, comm.rank(), comm.world_size(), alloc);
+        for(auto& block : mMBlockStorage) {
             fill_zero(block, stream);
         }
         zero_opt_non_block(mOptM, stream);
@@ -234,8 +144,8 @@ LLamaOptimizerStateManager::LLamaOptimizerStateManager(TransformerConfig cfg, LL
     {
         auto ctx = alloc.with_context("Adam V");
         EAllocationType alloc_type = options.OffloadOptV ? options.offload_alloc() : EAllocationType::ON_DEVICE;
-        mOptVBlockStorage = allocate_weights_opt(mOptV, cfg, options.OptVarianceType, alloc_type, comm.rank(), comm.world_size(), alloc);
-        for(auto& block : mOptVBlockStorage) {
+        mVBlockStorage = allocate_weights_opt(mOptV, cfg, options.OptVarianceType, alloc_type, comm.rank(), comm.world_size(), alloc);
+        for(auto& block : mVBlockStorage) {
             fill_zero(block, stream);
         }
         zero_opt_non_block(mOptV, stream);

--- a/src/models/llama_optimizer.h
+++ b/src/models/llama_optimizer.h
@@ -17,43 +17,24 @@ public:
     sLLamaNonBlockWeights<TensorShard>& non_block_v();
 
     void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream) override;
-    void end_optimizer(DeviceMemoryStack& memory) override;
 
     sLLamaWeights& full_m() { return mOptM; }
     sLLamaWeights& scales_m() { return mOptMScales; }
     sLLamaWeights& full_v() { return mOptV; }
 
-    void fetch_block(int layer_idx, cudaStream_t fetch_stream) override;
     SimpleTensorContainer& get_block_m(int layer_idx, cudaStream_t stream) override;
     SimpleTensorContainer& get_block_v(int layer_idx, cudaStream_t stream) override;
     SimpleTensorContainer& get_block_scales_m(int layer_idx) override;
-    void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream) override;
 private:
-    // mOptM.Blocks[i] and mOptMBlockStorage[i] alias the same memory.
+    // mOptM.Blocks[i] and mMBlockStorage[i] alias the same memory.
     // mOptM provides convenient access to the individual tensors of a block, whereas
-    // mOptMBlockStorage has just one large, byte-typed buffer for bulk transfers.
+    // mMBlockStorage has just one large, byte-typed buffer for bulk transfers.
     sLLamaWeights mOptM;
-    std::vector<Tensor> mOptMBlockStorage;
     sLLamaWeights mOptV;
-    std::vector<Tensor> mOptVBlockStorage;
-
-    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptMBuffer;
-    std::array<Tensor, 2> mOptMBufferStorage;
-    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptVBuffer;
-    std::array<Tensor, 2> mOptVBufferStorage;
-
     sLLamaWeights mOptMScales;
 
-    struct sBufferStatus {
-        int LayerIdx = -1;
-        cudaEvent_t DoneEvent = nullptr;
-        bool Fetch = false;
-        bool Done = true;
-    };
-
-    std::array<sBufferStatus, 2> mStatus;
-
-    sLLamaBlockWeights<TensorShard>& get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf);
+    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptMBuffer;
+    std::array<sLLamaBlockWeights<TensorShard>, 2> mOptVBuffer;
 };
 
 #endif //LLMQ_SRC_MODELS_LLAMA_OPTIMIZER_H

--- a/src/models/llama_optimizer.h
+++ b/src/models/llama_optimizer.h
@@ -7,28 +7,28 @@
 #define LLMQ_SRC_MODELS_LLAMA_OPTIMIZER_H
 
 #include "llama_weights.h"
+#include "training/adamw_optimizer.h"
 #include <array>
 
-class LLamaOptimizerStateManager {
+class LLamaOptimizerStateManager : public AdamWStateManager {
 public:
     LLamaOptimizerStateManager(TransformerConfig cfg, LLamaOptions options, cudaStream_t stream, NCCLCommunicator& comm, TensorAllocator& alloc);
     sLLamaNonBlockWeights<TensorShard>& non_block_m();
     sLLamaNonBlockWeights<TensorShard>& non_block_v();
 
-    void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream);
-    void end_optimizer(DeviceMemoryStack& memory);
+    void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream) override;
+    void end_optimizer(DeviceMemoryStack& memory) override;
 
     sLLamaWeights& full_m() { return mOptM; }
     sLLamaWeights& scales_m() { return mOptMScales; }
     sLLamaWeights& full_v() { return mOptV; }
 
-    void fetch_block(int layer_idx, cudaStream_t fetch_stream);
-    sLLamaBlockWeights<TensorShard>& get_block_m(int layer_idx, cudaStream_t stream);
-    sLLamaBlockWeights<TensorShard>& get_block_v(int layer_idx, cudaStream_t stream);
-    void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
+    void fetch_block(int layer_idx, cudaStream_t fetch_stream) override;
+    SimpleTensorContainer& get_block_m(int layer_idx, cudaStream_t stream) override;
+    SimpleTensorContainer& get_block_v(int layer_idx, cudaStream_t stream) override;
+    SimpleTensorContainer& get_block_scales_m(int layer_idx) override;
+    void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream) override;
 private:
-    TransformerConfig mConfig;
-
     // mOptM.Blocks[i] and mOptMBlockStorage[i] alias the same memory.
     // mOptM provides convenient access to the individual tensors of a block, whereas
     // mOptMBlockStorage has just one large, byte-typed buffer for bulk transfers.
@@ -52,13 +52,6 @@ private:
     };
 
     std::array<sBufferStatus, 2> mStatus;
-
-    bool mOffloadM;
-    bool mOffloadV;
-    bool mUseZeroCopy;
-
-    int mRank;
-    int mWorld;
 
     sLLamaBlockWeights<TensorShard>& get_block_from(int layer_idx, cudaStream_t stream, sLLamaBlockWeights<TensorShard>& buf);
 };

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -203,6 +203,31 @@ sLLamaWeights allocate_weights(const TransformerConfig& config, EAllocationType 
     return result;
 }
 
+void convert_dtype_for_gather(Tensor& src, Tensor& qnt, bool& convert, bool src_is_persistent, LLamaRunState& run_state) {
+    qnt.Stats = src.Stats;
+    if (qnt.DType == src.DType) {
+        // Identical tensors
+        if(qnt.Device == src.Device && src_is_persistent) {
+            qnt.Data = src.Data;
+            return;
+        } else {    // transfer to other device? (should just be GPU -> CPU)
+            CUDA_CHECK(cudaMemcpyAsync(qnt.Data, src.Data, qnt.bytes(), cudaMemcpyDefault, run_state.MainStream));
+            convert = true;
+            return;
+        }
+    }
+
+    quantize_with_abs_max(qnt, src.scale(), src, src.abs_max(), qnt.nelem(), run_state.DeviceProp, run_state.MainStream);
+    convert = true;
+}
+
+void convert_dtype_for_gather(SimpleTensorContainer& src, SimpleTensorContainer& qnt, bool& convert, bool src_is_persistent, LLamaRunState& run_state) {
+    visit([&](Tensor& s, Tensor& q) {
+        convert_dtype_for_gather(s, q, convert, src_is_persistent, run_state);
+    }, src, qnt);
+}
+
+
 LLamaWeightsManager::LLamaWeightsManager(const TransformerConfig& config, const LLamaOptions& options, int rank, int world) :
     mMasterDType(options.MasterDType.value_or(config.DType)), mWorkMatDType(options.matmul_dtype()),
     mShardIdx(rank), mNumShards(world), mConfig(config)
@@ -337,7 +362,8 @@ void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_s
     CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, stat.DoneEvent, 0));
     stat.LayerIdx = layer_idx;
     stat.Fetch = false;
-    auto fetch = [fetch_stream, &stat](TensorShard& dst, TensorShard& src) {
+
+    visit([fetch_stream, &stat](Tensor& dst, Tensor& src){
         // tensors on the same device are handled by pointer assignment
         if(dst.Device == src.Device) {
             dst.Data = src.Data;
@@ -347,17 +373,7 @@ void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_s
             dst.Stats = src.Stats;
             stat.Fetch = true;
         }
-    };
-
-    fetch(buf.LN1_w, ref.LN1_w);
-    fetch(buf.LN2_w, ref.LN2_w);
-    fetch(buf.Attn_QKV_w, ref.Attn_QKV_w);
-    fetch(buf.Attn_Out_w, ref.Attn_Out_w);
-    fetch(buf.MLP_Up_w, ref.MLP_Up_w);
-    fetch(buf.MLP_Down_w, ref.MLP_Down_w);
-    if (ref.Attn_QKV_b) {
-        fetch(buf.Attn_QKV_b, ref.Attn_QKV_b);
-    }
+        }, buf, ref);
 
     if(stat.Fetch) {
         CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
@@ -383,13 +399,6 @@ void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t strea
     auto& stat = mMasterDeviceBufferStatus.at(buffer);
     auto& ref = mMaster.Blocks[layer_idx];
 
-    auto send = [put_stream](TensorShard& dst, TensorShard& src) {
-        // tensors on the same device are handled by pointer assignment
-        if(dst.Device != src.Device) {
-            CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyDeviceToHost, put_stream));
-        }
-    };
-
     auto& src = mMasterDeviceDoubleBuffer.at(buffer);
     auto& qnt = lookup_block_quants(layer_idx);
 
@@ -400,29 +409,18 @@ void LLamaWeightsManager::release_master_block(int layer_idx, cudaStream_t strea
     bool convert_any = false;
     if (qnt.LayerIdx == layer_idx) {
         NvtxRange q_rng("quantize");
-        convert_dtype_for_gather(src.LN1_w, qnt.Block.LN1_w, convert_any, !mOffloadMaster, run_state);
-        convert_dtype_for_gather(src.LN2_w, qnt.Block.LN2_w, convert_any, !mOffloadMaster, run_state);
-        convert_dtype_for_gather(src.Attn_QKV_w, qnt.Block.Attn_QKV_w, convert_any, !mOffloadMaster, run_state);
-        convert_dtype_for_gather(src.Attn_Out_w, qnt.Block.Attn_Out_w, convert_any, !mOffloadMaster, run_state);
-        convert_dtype_for_gather(src.MLP_Up_w, qnt.Block.MLP_Up_w, convert_any, !mOffloadMaster, run_state);
-        convert_dtype_for_gather(src.MLP_Down_w, qnt.Block.MLP_Down_w, convert_any, !mOffloadMaster, run_state);
-        if (src.Attn_QKV_b) {
-            convert_dtype_for_gather(src.Attn_QKV_b, qnt.Block.Attn_QKV_b, convert_any, !mOffloadMaster, run_state);
-        }
+        convert_dtype_for_gather(src, qnt.Block, convert_any, !mOffloadMaster, run_state);
         // indicate that this is already the version for the next step
         qnt.Version = mVersion + 1;
     }
     CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
 
-    send(ref.LN1_w, buf.LN1_w);
-    send(ref.LN2_w, buf.LN2_w);
-    send(ref.Attn_QKV_w, buf.Attn_QKV_w);
-    send(ref.Attn_Out_w, buf.Attn_Out_w);
-    send(ref.MLP_Up_w, buf.MLP_Up_w);
-    send(ref.MLP_Down_w, buf.MLP_Down_w);
-    if (ref.Attn_QKV_b) {
-        send(ref.Attn_QKV_b, buf.Attn_QKV_b);
-    }
+    visit([put_stream](Tensor& dst, Tensor& src){
+        // tensors on the same device are handled by pointer assignment
+        if(dst.Device != src.Device) {
+            CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyDeviceToHost, put_stream));
+        }
+    }, ref, buf);
 
     // put is only considered complete once *both* master weights *and* quants
     // are finished.
@@ -468,24 +466,6 @@ void LLamaWeightsManager::release_status(sGatherData& data, int expected, cudaSt
     data.Done = true;
 }
 
-void LLamaWeightsManager::convert_dtype_for_gather(TensorShard& src, TensorShard& qnt, bool& convert, bool src_is_persistent, LLamaRunState& run_state) {
-    qnt.Stats = src.Stats;
-    if (qnt.DType == src.DType) {
-        // Identical tensors
-        if(qnt.Device == src.Device && src_is_persistent) {
-            qnt.Data = src.Data;
-            return;
-        } else {    // transfer to other device? (should just be GPU -> CPU)
-            CUDA_CHECK(cudaMemcpyAsync(qnt.Data, src.Data, qnt.bytes(), cudaMemcpyDefault, run_state.MainStream));
-            convert = true;
-            return;
-        }
-    }
-
-    quantize_with_abs_max(qnt, src.scale(), src, src.abs_max(), qnt.nelem(), run_state.DeviceProp, run_state.MainStream);
-    convert = true;
-}
-
 void LLamaWeightsManager::gather_block(int layer_idx, NCCLCommunicator& comm, LLamaRunState& run_state) {
     auto& src = mMaster.Blocks[layer_idx];
     auto& qnt = lookup_block_quants(layer_idx);
@@ -502,43 +482,21 @@ void LLamaWeightsManager::gather_block(int layer_idx, NCCLCommunicator& comm, LL
     bool convert_any = false;
     if (qnt.Version != mVersion || qnt.LayerIdx != layer_idx) {
         NvtxRange q_rng("quantize");
-        convert_dtype_for_gather(src.LN1_w, qnt.Block.LN1_w, convert_any, true, run_state);
-        convert_dtype_for_gather(src.LN2_w, qnt.Block.LN2_w, convert_any, true, run_state);
-        convert_dtype_for_gather(src.Attn_QKV_w, qnt.Block.Attn_QKV_w, convert_any, true, run_state);
-        convert_dtype_for_gather(src.Attn_Out_w, qnt.Block.Attn_Out_w, convert_any, true, run_state);
-        convert_dtype_for_gather(src.MLP_Up_w, qnt.Block.MLP_Up_w, convert_any, true, run_state);
-        convert_dtype_for_gather(src.MLP_Down_w, qnt.Block.MLP_Down_w, convert_any, true, run_state);
-        if (src.Attn_QKV_b) {
-            convert_dtype_for_gather(src.Attn_QKV_b, qnt.Block.Attn_QKV_b, convert_any, true, run_state);
-        }
-
+        convert_dtype_for_gather(src, qnt.Block, convert_any, true, run_state);
         qnt.Version = mVersion;
         qnt.LayerIdx = layer_idx;
     }
-
-    // make sure the target scales are set up correctly
-    dst.LN1_w.Stats = qnt.Block.LN1_w.Stats;
-    dst.LN2_w.Stats = qnt.Block.LN2_w.Stats;
-    dst.Attn_QKV_w.Stats = qnt.Block.Attn_QKV_w.Stats;
-    dst.Attn_QKV_b.Stats = qnt.Block.Attn_QKV_b.Stats;
-    dst.Attn_Out_w.Stats = qnt.Block.Attn_Out_w.Stats;
-    dst.MLP_Up_w.Stats = qnt.Block.MLP_Up_w.Stats;
-    dst.MLP_Down_w.Stats = qnt.Block.MLP_Down_w.Stats;
 
     if (convert_any) {
         CUDA_CHECK(cudaEventRecord(gather_data.DoneEvent, run_state.MainStream));
     }
 
     comm.begin_transaction(gather_data.DoneEvent);
-    comm.schedule_all_gather(qnt.Block.LN1_w, dst.LN1_w);
-    comm.schedule_all_gather(qnt.Block.LN2_w, dst.LN2_w);
-    comm.schedule_all_gather(qnt.Block.Attn_QKV_w, dst.Attn_QKV_w);
-    if (src.Attn_QKV_b) {
-        comm.schedule_all_gather(qnt.Block.Attn_QKV_b, dst.Attn_QKV_b);
-    }
-    comm.schedule_all_gather(qnt.Block.Attn_Out_w, dst.Attn_Out_w);
-    comm.schedule_all_gather(qnt.Block.MLP_Up_w, dst.MLP_Up_w);
-    comm.schedule_all_gather(qnt.Block.MLP_Down_w, dst.MLP_Down_w);
+    visit([&](Tensor& q, Tensor& d) {
+        // make sure the target scales are set up correctly, in addition to copying the data
+        d.Stats = q.Stats;
+        comm.schedule_all_gather(q, d);
+    }, qnt.Block, dst);
     comm.execute_transaction(gather_data.DoneEvent);
 }
 
@@ -861,24 +819,10 @@ void LLamaWeightsManager::synchronize_absmax(NCCLCommunicator& comm) {
 
     // in order to reach a consistent state, like after an optimizer step, we need to calculate the abs-maxes
     for (auto& layer : mMaster.Blocks) {
-        abs_max(layer.LN1_w.abs_max(), layer.LN1_w, layer.LN1_w.nelem(), dp, nullptr);
-        abs_max(layer.LN2_w.abs_max(), layer.LN2_w, layer.LN2_w.nelem(), dp, nullptr);
-        abs_max(layer.Attn_QKV_w.abs_max(), layer.Attn_QKV_w, layer.Attn_QKV_w.nelem(), dp, nullptr);
-        abs_max(layer.Attn_Out_w.abs_max(), layer.Attn_Out_w, layer.Attn_Out_w.nelem(), dp, nullptr);
-        abs_max(layer.MLP_Up_w.abs_max(), layer.MLP_Up_w, layer.MLP_Up_w.nelem(), dp, nullptr);
-        abs_max(layer.MLP_Down_w.abs_max(), layer.MLP_Down_w, layer.MLP_Down_w.nelem(), dp, nullptr);
-        if (layer.Attn_QKV_b) {
-            abs_max(layer.Attn_QKV_b.abs_max(), layer.Attn_QKV_b, layer.Attn_QKV_b.nelem(), dp, nullptr);
-        }
-        comm.reduce_max(layer.LN1_w.abs_max());
-        comm.reduce_max(layer.LN2_w.abs_max());
-        comm.reduce_max(layer.Attn_QKV_w.abs_max());
-        comm.reduce_max(layer.Attn_Out_w.abs_max());
-        comm.reduce_max(layer.MLP_Up_w.abs_max());
-        comm.reduce_max(layer.MLP_Down_w.abs_max());
-        if (layer.Attn_QKV_b) {
-            comm.reduce_max(layer.Attn_QKV_b.abs_max());
-        }
+        visit([&](Tensor& w){
+            abs_max(w.abs_max(), w, w.nelem(), dp, nullptr);
+            comm.reduce_max(w.abs_max());
+        }, layer);
         comm.wait_on_comms(nullptr);
     }
     comm.barrier();     // make sure all import is done before any process proceeds.

--- a/src/models/llama_weights.cpp
+++ b/src/models/llama_weights.cpp
@@ -380,7 +380,7 @@ void LLamaWeightsManager::fetch_master_block(int layer_idx, cudaStream_t fetch_s
     }
 }
 
-sLLamaBlockWeights<TensorShard>& LLamaWeightsManager::get_master_block(int layer_idx, cudaStream_t stream) {
+SimpleTensorContainer& LLamaWeightsManager::get_master_block(int layer_idx, cudaStream_t stream) {
     if(!mOffloadMaster || mUseZeroCopy) return mMaster.Blocks[layer_idx];
 
     int buffer = layer_idx % 2;

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -23,13 +23,13 @@ enum class EAllocationType : int;
 typedef struct CUevent_st* cudaEvent_t;
 
 namespace LLamaWeightID {
-    static constexpr unsigned LN1_W = 0;
-    static constexpr unsigned LN2_W = 1;
-    static constexpr unsigned QKV_W = 2;
-    static constexpr unsigned QKV_B = 3;
-    static constexpr unsigned ATTO_W = 4;
-    static constexpr unsigned UP_W = 5;
-    static constexpr unsigned DOWN_W = 6;
+    inline constexpr unsigned LN1_W = 0;
+    inline constexpr unsigned LN2_W = 1;
+    inline constexpr unsigned QKV_W = 2;
+    inline constexpr unsigned QKV_B = 3;
+    inline constexpr unsigned ATTO_W = 4;
+    inline constexpr unsigned UP_W = 5;
+    inline constexpr unsigned DOWN_W = 6;
 };
 
 template<class TTensor>
@@ -43,7 +43,7 @@ struct sLLamaBlockWeights : public SimpleTensorContainer {
     TTensor MLP_Down_w;
 
     std::size_t num_tensors() const noexcept override { return 7; }
-    const Tensor& get_tensor(unsigned idx) const override {
+    const Tensor& get_tensor(std::size_t idx) const override {
         using namespace LLamaWeightID;
         switch (idx) {
             case LN1_W: return LN1_w;

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -22,6 +22,16 @@ class LazyAllocator;
 enum class EAllocationType : int;
 typedef struct CUevent_st* cudaEvent_t;
 
+namespace LLamaWeightID {
+    static constexpr unsigned LN1_W = 0;
+    static constexpr unsigned LN2_W = 1;
+    static constexpr unsigned QKV_W = 2;
+    static constexpr unsigned QKV_B = 3;
+    static constexpr unsigned ATTO_W = 4;
+    static constexpr unsigned UP_W = 5;
+    static constexpr unsigned DOWN_W = 6;
+};
+
 template<class TTensor>
 struct sLLamaBlockWeights : public SimpleTensorContainer {
     TTensor LN1_w;           // C
@@ -34,14 +44,15 @@ struct sLLamaBlockWeights : public SimpleTensorContainer {
 
     std::size_t num_tensors() const noexcept override { return 7; }
     const Tensor& get_tensor(unsigned idx) const override {
+        using namespace LLamaWeightID;
         switch (idx) {
-            case 0: return LN1_w;
-            case 1: return LN2_w;
-            case 2: return Attn_QKV_w;
-            case 3: return Attn_QKV_b;
-            case 4: return Attn_Out_w;
-            case 5: return MLP_Up_w;
-            case 6: return MLP_Down_w;
+            case LN1_W: return LN1_w;
+            case LN2_W: return LN2_w;
+            case QKV_W: return Attn_QKV_w;
+            case QKV_B: return Attn_QKV_b;
+            case ATTO_W: return Attn_Out_w;
+            case UP_W: return MLP_Up_w;
+            case DOWN_W: return MLP_Down_w;
             default:
                 throw std::out_of_range("Invalid tensor index");
         }
@@ -105,7 +116,7 @@ public:
     //! they are being fetched from the host.
     //! \param layer_idx The layer for which master weights are requested
     //! \param stream The stream which to block until the preceding gather_master_block has completed.
-    sLLamaBlockWeights<TensorShard>& get_master_block(int layer_idx, cudaStream_t stream);
+    SimpleTensorContainer& get_master_block(int layer_idx, cudaStream_t stream);
 
     //! Indicate that the optimizer has finished updating the master weight.
     //! If they are not offloaded, this function does nothing.

--- a/src/models/llama_weights.h
+++ b/src/models/llama_weights.h
@@ -23,7 +23,7 @@ enum class EAllocationType : int;
 typedef struct CUevent_st* cudaEvent_t;
 
 template<class TTensor>
-struct sLLamaBlockWeights {
+struct sLLamaBlockWeights : public SimpleTensorContainer {
     TTensor LN1_w;           // C
     TTensor LN2_w;           // C
     TTensor Attn_QKV_w;      // ((Hq + 2Hkv)Hd, C)
@@ -31,6 +31,21 @@ struct sLLamaBlockWeights {
     TTensor Attn_Out_w;      //
     TTensor MLP_Up_w;
     TTensor MLP_Down_w;
+
+    std::size_t num_tensors() const noexcept override { return 7; }
+    const Tensor& get_tensor(unsigned idx) const override {
+        switch (idx) {
+            case 0: return LN1_w;
+            case 1: return LN2_w;
+            case 2: return Attn_QKV_w;
+            case 3: return Attn_QKV_b;
+            case 4: return Attn_Out_w;
+            case 5: return MLP_Up_w;
+            case 6: return MLP_Down_w;
+            default:
+                throw std::out_of_range("Invalid tensor index");
+        }
+    }
 };
 
 template<class TTensor>
@@ -161,8 +176,6 @@ protected:
     bool is_in_cache(sGatherData& data, int expected) const;
     void update_get_status(sGatherData& data, int expected, cudaStream_t stream) const;
     void release_status(sGatherData& data, int expected, cudaStream_t stream);
-
-    void convert_dtype_for_gather(TensorShard& src, TensorShard& qnt, bool& convert, bool src_is_persistent, LLamaRunState& run_state);
 
     TransformerConfig mConfig;
     long HQ;    // number of query heads

--- a/src/training/adamw_optimizer.cpp
+++ b/src/training/adamw_optimizer.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "adamw_optimizer.h"
+#include "utilities/utils.h"
+#include "utilities/tensor.h"
+#include "utilities/stack.h"
+
+
+void AdamWStateManager::end_optimizer(DeviceMemoryStack& memory) {
+    if(mOffloadV &&! mUseZeroCopy) {
+        memory.free(mVBufferStorage[1]);
+        memory.free(mVBufferStorage[0]);
+    }
+
+    if(mOffloadM &&! mUseZeroCopy) {
+        memory.free(mMBufferStorage[1]);
+        memory.free(mMBufferStorage[0]);
+    }
+}
+
+
+void AdamWStateManager::fetch_block(int layer_idx, cudaStream_t fetch_stream) {
+    if((!mOffloadM && !mOffloadV) || mUseZeroCopy) return;
+
+    NvtxRange range("fetch_opt_block", layer_idx);
+    int buffer = layer_idx % 2;
+    auto& stat = mStatus.at(buffer);
+    stat.LayerIdx = layer_idx;
+    stat.Fetch = true;
+
+    CUDA_CHECK(cudaStreamWaitEvent(fetch_stream, stat.DoneEvent, 0));
+
+    auto fetch = [fetch_stream](Tensor& dst, Tensor& src) {
+        CUDA_CHECK(cudaMemcpyAsync(dst.Data, src.Data, dst.bytes(), cudaMemcpyHostToDevice, fetch_stream));
+        dst.Stats = src.Stats;
+    };
+
+    if(mOffloadM) {
+        auto& buf = mMBufferStorage.at(buffer);
+        auto& ref = mMBlockStorage.at(layer_idx);
+
+        fetch(buf, ref);
+    }
+
+    if(mOffloadV) {
+        auto& buf = mVBufferStorage.at(buffer);
+        auto& ref = mVBlockStorage.at(layer_idx);
+
+        fetch(buf, ref);
+    }
+
+    CUDA_CHECK(cudaEventRecord(stat.DoneEvent, fetch_stream));
+}
+
+void AdamWStateManager::store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream)  {
+    if (mUseZeroCopy) return;
+
+    NvtxRange range("store_opt_block", layer_idx);
+    int buffer = layer_idx % 2;
+    auto& stat = mStatus.at(layer_idx % 2);
+    if(mOffloadM || mOffloadV) {
+        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, stream));
+        CUDA_CHECK(cudaStreamWaitEvent(put_stream, stat.DoneEvent, 0));
+    }
+
+    if(mOffloadM) {
+        CUDA_CHECK(cudaMemcpyAsync(mMBlockStorage.at(layer_idx).Data, mMBufferStorage.at(buffer).Data, mMBlockStorage.at(layer_idx).bytes(), cudaMemcpyDeviceToHost, put_stream));
+    }
+
+    if(mOffloadV) {
+        CUDA_CHECK(cudaMemcpyAsync(mVBlockStorage.at(layer_idx).Data, mVBufferStorage.at(buffer).Data, mVBlockStorage.at(layer_idx).bytes(), cudaMemcpyDeviceToHost, put_stream));
+    }
+
+    if(mOffloadM || mOffloadV) {
+        if(stat.LayerIdx != layer_idx) {
+            throw std::logic_error("layer index mismatch in store_block");
+        }
+        CUDA_CHECK(cudaEventRecord(stat.DoneEvent, put_stream));
+        stat.Done = true;
+    }
+}
+
+SimpleTensorContainer& AdamWStateManager::get_block_from(int layer_idx, cudaStream_t stream, SimpleTensorContainer &buf) {
+    int buffer = layer_idx % 2;
+    auto& stat = mStatus.at(buffer);
+
+    if(stat.LayerIdx != layer_idx) {
+        throw std::logic_error("Layer index mismatch in get_block_from");
+    }
+
+    stat.Done = false;
+    // if we needed to fetch, we need to wait
+    if(stat.Fetch) {
+        CUDA_CHECK(cudaStreamWaitEvent(stream, stat.DoneEvent, 0));
+    }
+    stat.Fetch = false;
+
+    return buf;
+}

--- a/src/training/adamw_optimizer.h
+++ b/src/training/adamw_optimizer.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#ifndef LLMQ_ADAMW_OPTIMIZER_H
+#define LLMQ_ADAMW_OPTIMIZER_H
+
+#include "transformer_config.h"
+#include "utilities/tensor_container.h"
+
+typedef struct CUstream_st *cudaStream_t;
+
+class DeviceMemoryStack;
+
+class AdamWStateManager {
+public:
+    AdamWStateManager(TransformerConfig cfg, bool offload_m, bool offload_v, bool zero_copy, int rank, int world) :
+        mConfig(cfg), mOffloadM(offload_m), mOffloadV(offload_v), mUseZeroCopy(zero_copy), mRank(rank), mWorld(world) {}
+    virtual ~AdamWStateManager() = default;
+    virtual void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream) = 0;
+    virtual void end_optimizer(DeviceMemoryStack& memory) = 0;
+
+    virtual void fetch_block(int layer_idx, cudaStream_t fetch_stream) = 0;
+    virtual SimpleTensorContainer& get_block_m(int layer_idx, cudaStream_t stream) = 0;
+    virtual SimpleTensorContainer& get_block_v(int layer_idx, cudaStream_t stream) = 0;
+    virtual SimpleTensorContainer& get_block_scales_m(int layer_idx) = 0;
+    virtual void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream) = 0;
+
+protected:
+    TransformerConfig mConfig;
+
+    bool mOffloadM;
+    bool mOffloadV;
+    bool mUseZeroCopy;
+
+    int mRank;
+    int mWorld;
+};
+
+#endif //LLMQ_ADAMW_OPTIMIZER_H

--- a/src/training/adamw_optimizer.h
+++ b/src/training/adamw_optimizer.h
@@ -8,6 +8,7 @@
 
 #include "transformer_config.h"
 #include "utilities/tensor_container.h"
+#include "utilities/tensor.h"
 
 typedef struct CUstream_st *cudaStream_t;
 
@@ -19,15 +20,17 @@ public:
         mConfig(cfg), mOffloadM(offload_m), mOffloadV(offload_v), mUseZeroCopy(zero_copy), mRank(rank), mWorld(world) {}
     virtual ~AdamWStateManager() = default;
     virtual void begin_optimizer(DeviceMemoryStack& memory, cudaStream_t main_stream) = 0;
-    virtual void end_optimizer(DeviceMemoryStack& memory) = 0;
+    virtual void end_optimizer(DeviceMemoryStack& memory);
 
-    virtual void fetch_block(int layer_idx, cudaStream_t fetch_stream) = 0;
+    void fetch_block(int layer_idx, cudaStream_t fetch_stream);
     virtual SimpleTensorContainer& get_block_m(int layer_idx, cudaStream_t stream) = 0;
     virtual SimpleTensorContainer& get_block_v(int layer_idx, cudaStream_t stream) = 0;
     virtual SimpleTensorContainer& get_block_scales_m(int layer_idx) = 0;
-    virtual void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream) = 0;
+    virtual void store_block(int layer_idx, cudaStream_t stream, cudaStream_t put_stream);
 
 protected:
+    SimpleTensorContainer& get_block_from(int layer_idx, cudaStream_t stream, SimpleTensorContainer& buf);
+
     TransformerConfig mConfig;
 
     bool mOffloadM;
@@ -36,6 +39,20 @@ protected:
 
     int mRank;
     int mWorld;
+
+    struct sBufferStatus {
+        int LayerIdx = -1;
+        cudaEvent_t DoneEvent = nullptr;
+        bool Fetch = false;
+        bool Done = true;
+    };
+
+    std::vector<Tensor> mMBlockStorage;
+    std::vector<Tensor> mVBlockStorage;
+
+    std::array<Tensor, 2> mMBufferStorage;
+    std::array<Tensor, 2> mVBufferStorage;
+    std::array<sBufferStatus, 2> mStatus;
 };
 
 #endif //LLMQ_ADAMW_OPTIMIZER_H

--- a/src/utilities/tensor.cpp
+++ b/src/utilities/tensor.cpp
@@ -117,7 +117,7 @@ TensorShard shard_view(const Tensor& src, int idx, int num) {
 
 void visit(const std::function<void(Tensor&)>& func, SimpleTensorContainer& container) {
     auto cs = container.num_tensors();
-    for(unsigned i = 0; i < cs; ++i) {
+    for(std::size_t i = 0; i < cs; ++i) {
         auto& t = container.get_tensor(i);
         if(t) {
             func(t);
@@ -127,15 +127,15 @@ void visit(const std::function<void(Tensor&)>& func, SimpleTensorContainer& cont
 
 void visit(const std::function<void(Tensor&, Tensor&)>& func, SimpleTensorContainer& a, SimpleTensorContainer& b) {
     if(a.num_tensors() != b.num_tensors()) {
-        throw std::logic_error(fmt::format("TensorContainer size mismatch: {} != {}", a.num_tensors(), b.num_tensors()));
+        throw std::invalid_argument(fmt::format("TensorContainer size mismatch: {} != {}", a.num_tensors(), b.num_tensors()));
     }
 
     auto cs = a.num_tensors();
-    for(unsigned i = 0; i < cs; ++i) {
+    for(std::size_t i = 0; i < cs; ++i) {
         auto& t1 = a.get_tensor(i);
         auto& t2 = b.get_tensor(i);
         if(t1.empty() != t2.empty()) {
-            throw std::logic_error(fmt::format("TensorContainer structure mismatch at tensor {}", i));
+            throw std::invalid_argument(fmt::format("TensorContainer structure mismatch at tensor {}", i));
         }
         if(t1 && t2) {
             func(t1, t2);

--- a/src/utilities/tensor.cpp
+++ b/src/utilities/tensor.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "tensor.h"
+#include "tensor_container.h"
 
 #include <iostream>
 #include <vector>
+#include <fmt/core.h>
 
 #include <cuda_fp8.h>
 
@@ -111,4 +113,32 @@ TensorShard shard_view(const Tensor& src, int idx, int num) {
         shard.Data = src.Data + div_exact(src.bytes(), static_cast<std::size_t>(num)) * idx;
     }
     return TensorShard{shard, idx, num, src.Sizes};
+}
+
+void visit(const std::function<void(Tensor&)>& func, SimpleTensorContainer& container) {
+    auto cs = container.num_tensors();
+    for(unsigned i = 0; i < cs; ++i) {
+        auto& t = container.get_tensor(i);
+        if(t) {
+            func(t);
+        }
+    }
+}
+
+void visit(const std::function<void(Tensor&, Tensor&)>& func, SimpleTensorContainer& a, SimpleTensorContainer& b) {
+    if(a.num_tensors() != b.num_tensors()) {
+        throw std::logic_error(fmt::format("TensorContainer size mismatch: {} != {}", a.num_tensors(), b.num_tensors()));
+    }
+
+    auto cs = a.num_tensors();
+    for(unsigned i = 0; i < cs; ++i) {
+        auto& t1 = a.get_tensor(i);
+        auto& t2 = b.get_tensor(i);
+        if(t1.empty() != t2.empty()) {
+            throw std::logic_error(fmt::format("TensorContainer structure mismatch at tensor {}", i));
+        }
+        if(t1 && t2) {
+            func(t1, t2);
+        }
+    }
 }

--- a/src/utilities/tensor_container.h
+++ b/src/utilities/tensor_container.h
@@ -7,9 +7,31 @@
 #define LLMQ_SRC_UTILS_TENSOR_CONTAINER_H
 
 #include <functional>
+#include <cstddef>
 #include <string>
 
+class Tensor;
 class TensorShard;
+
+class SimpleTensorContainer {
+public:
+    virtual std::size_t num_tensors() const noexcept = 0;
+    virtual const Tensor& get_tensor(unsigned idx) const = 0;
+
+    Tensor& get_tensor(unsigned idx) {
+        return const_cast<Tensor&>(const_cast<const SimpleTensorContainer&>(*this).get_tensor(idx));
+    }
+protected:
+    ~SimpleTensorContainer() = default;
+};
+
+//! \brief Apply the given function to all _non-empty_ tensors in `container`
+void visit(const std::function<void(Tensor&)>& func, SimpleTensorContainer& container);
+
+//! \brief Apply the given function to all _non-empty_ tensors in `a` and `b`.
+//! \details `a` and `b` must have the same number of tensors, and empty tensors must be at the same indices
+//! in both containers.
+void visit(const std::function<void(Tensor&, Tensor&)>& func, SimpleTensorContainer& a, SimpleTensorContainer& b);
 
 class ITensorContainer {
   public:

--- a/src/utilities/tensor_container.h
+++ b/src/utilities/tensor_container.h
@@ -13,15 +13,22 @@
 class Tensor;
 class TensorShard;
 
+//! \brief Base class for an object that supports iterating over its tensors
 class SimpleTensorContainer {
 public:
+    //! Get the total number of tensors in this container. This count includes empty tensors.
     virtual std::size_t num_tensors() const noexcept = 0;
-    virtual const Tensor& get_tensor(unsigned idx) const = 0;
 
-    Tensor& get_tensor(unsigned idx) {
+    //! Return a constant reference to the tensor at the given index.
+    virtual const Tensor& get_tensor(std::size_t idx) const = 0;
+
+    //! Return a mutable reference to the tensor at the given index.
+    //! Implemented in terms of const `get_tensor`.
+    Tensor& get_tensor(std::size_t idx) {
         return const_cast<Tensor&>(const_cast<const SimpleTensorContainer&>(*this).get_tensor(idx));
     }
 protected:
+    //! Protected destructor: Don't delete through `SimpleTensorContainer` pointers.
     ~SimpleTensorContainer() = default;
 };
 


### PR DESCRIPTION
Avoid having to spell out the contents of the transformer block every time; instead, define a generic collection that provides an interface that can be iterated over.  This enables the first steps towards making the optimizer code model independent.