### PR TITLE
TMA implementation for fused_classifier_kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ add_library(llmq-common SHARED
         src/kernels/adamw.cu
         src/kernels/attention.cu
         src/kernels/fused_classifier.cu
+        src/kernels/fused_classifier_tma.cu
         src/kernels/transpose.cu
         src/kernels/vector_add.cu
         src/kernels/random.cu

--- a/src/kernels/fused_classifier.cu
+++ b/src/kernels/fused_classifier.cu
@@ -210,7 +210,7 @@ void fused_classifier_dispatch(Type* logits, float* losses, float* lse,
     CUDA_CHECK(cudaGetDevice(&device));
     int major;
     CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device));
-    if ((major == 9 || major == 10) && write_dlogits == true && V % 8 == 0) {
+    if ((major == 9 || major == 10) && write_dlogits == true && V % (8 * 16 / sizeof(Type)) == 0) {
         // while the TMA implementation also works on CC12, it doesn't seem to bring performance
         // benefits so far.
         fused_classifier_tma(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);

--- a/src/kernels/fused_classifier.cu
+++ b/src/kernels/fused_classifier.cu
@@ -210,7 +210,7 @@ void fused_classifier_dispatch(Type* logits, float* losses, float* lse,
     CUDA_CHECK(cudaGetDevice(&device));
     int major;
     CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device));
-    if (major == 9 || major == 10 && write_dlogits == true) {
+    if ((major == 9 || major == 10) && write_dlogits == true && V % 8 == 0) {
         fused_classifier_tma(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);
     } else {
         fused_classifier_imp(logits, losses, lse, dloss, targets, z_reg, BT, V, P, write_dlogits, stream);

--- a/src/kernels/fused_classifier.cu
+++ b/src/kernels/fused_classifier.cu
@@ -211,6 +211,8 @@ void fused_classifier_dispatch(Type* logits, float* losses, float* lse,
     int major;
     CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device));
     if ((major == 9 || major == 10) && write_dlogits == true && V % 8 == 0) {
+        // while the TMA implementation also works on CC12, it doesn't seem to bring performance
+        // benefits so far.
         fused_classifier_tma(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);
     } else {
         fused_classifier_imp(logits, losses, lse, dloss, targets, z_reg, BT, V, P, write_dlogits, stream);

--- a/src/kernels/fused_classifier.cu
+++ b/src/kernels/fused_classifier.cu
@@ -193,15 +193,40 @@ void fused_classifier_imp(Type* logits, float* losses, float* lse,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void fused_classifier(float* logits, float* losses, float* lse,
-                      const float dloss, const int* targets, const float z_loss,
-                      int BT, int V, int P, bool write_dlogits, cudaStream_t stream) {
-    fused_classifier_imp(logits, losses, lse, dloss, targets, z_loss, BT, V, P, write_dlogits, stream);
+void fused_classifier_tma(float* logits, float* losses, float* lse,
+                          float dloss, const int* targets, float z_reg,
+                          int BT, int V, int P, cudaStream_t stream);
+
+void fused_classifier_tma(nv_bfloat16* logits, float* losses, float* lse,
+                          float dloss, const int* targets, float z_reg,
+                          int BT, int V, int P, cudaStream_t stream);
+
+template <typename Type>
+void fused_classifier_dispatch(Type* logits, float* losses, float* lse,
+                      const float dloss, const int* targets, float z_reg,
+                      int BT, int V, int P, bool write_dlogits, cudaStream_t stream)
+{
+    int device;
+    CUDA_CHECK(cudaGetDevice(&device));
+    int major;
+    CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device));
+    if (major == 9 || major == 10 && write_dlogits == true) {
+        fused_classifier_tma(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);
+    } else {
+        fused_classifier_imp(logits, losses, lse, dloss, targets, z_reg, BT, V, P, write_dlogits, stream);
+    }
 }
-void fused_classifier(nv_bfloat16* logits, float* losses, float* lse,
-                      const float dloss, const int* targets, const float z_loss,
+
+void fused_classifier(float* logits, float* losses, float* lse,
+                      const float dloss, const int* targets, const float z_reg,
                       int BT, int V, int P, bool write_dlogits, cudaStream_t stream) {
-    fused_classifier_imp(logits, losses, lse, dloss, targets, z_loss, BT, V, P, write_dlogits, stream);
+    fused_classifier_dispatch(logits, losses, lse, dloss, targets, z_reg, BT, V, P, write_dlogits, stream);
+}
+
+void fused_classifier(nv_bfloat16* logits, float* losses, float* lse,
+                      const float dloss, const int* targets, const float z_reg,
+                      int BT, int V, int P, bool write_dlogits, cudaStream_t stream) {
+    fused_classifier_dispatch(logits, losses, lse, dloss, targets, z_reg, BT, V, P, write_dlogits, stream);
 }
 
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -108,19 +108,41 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(256, 2)
     bar.wait(std::move(token));
 
     // OK, all logits for _this_ block are ready here. Calculate logsumexp
-    for (int i = threadIdx.x * x128::size; i < logits_per_block; i += x128::size * BLOCK_SIZE) {
-        x128 v = x128::load(smem_logits + i);
-        floatX old_maxval = thread_max;
-        for(int k = 0; k < x128::size; ++k) {
-            thread_max = dispatch_max(thread_max, v[k]);
+    {
+        int i = threadIdx.x * x128::size;
+        for (; i + x128::size * BLOCK_SIZE < logits_per_block; i += 2 * x128::size * BLOCK_SIZE) {
+            x128 v1 = x128::load(smem_logits + i);
+            x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
+            floatX old_maxval = thread_max;
+            for(int k = 0; k < x128::size; ++k) {
+                floatX m = dispatch_max(v1[k], v2[k]);
+                thread_max = dispatch_max(thread_max, m);
+            }
+            // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
+            // FMA, but that costs the same), but could give slightly less rounding error accumulation.
+            float vec_sum = 0.f;
+            for(int k = 0; k < x128::size; ++k) {
+                vec_sum += expf(static_cast<float>(v1[k] - thread_max));
+                vec_sum += expf(static_cast<float>(v2[k] - thread_max));
+            }
+            thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
         }
-        // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
-        // FMA, but that costs the same), but could give slightly less rounding error accumulation.
-        float vec_sum = 0.f;
-        for(int k = 0; k < x128::size; ++k) {
-            vec_sum += expf(static_cast<float>(v[k] - thread_max));
+
+        // epilogue
+        if (i  < logits_per_block) {
+            x128 v = x128::load(smem_logits + i);
+            floatX old_maxval = thread_max;
+            for(int k = 0; k < x128::size; ++k) {
+                thread_max = dispatch_max(thread_max, v[k]);
+            }
+            // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
+            // FMA, but that costs the same), but could give slightly less rounding error accumulation.
+            float vec_sum = 0.f;
+            for(int k = 0; k < x128::size; ++k) {
+                vec_sum += expf(static_cast<float>(v[k] - thread_max));
+            }
+            thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
         }
-        thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
     }
 
     floatX warp_max = warpReduceMax(thread_max);

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -45,6 +45,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
                              int V, int P) {
     #if __CUDA_ARCH__ >= 900
     constexpr int BLOCK_SIZE = 128;
+    constexpr float kLog2e = 1.4426950408889634f;
     using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
     using barrier = cuda::barrier<cuda::thread_scope_block>;
 
@@ -114,11 +115,13 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
         // FMA, but that costs the same), but could give slightly less rounding error accumulation.
         float vec_sum = 0.f;
+        float log2_thread_max = thread_max * kLog2e;
+
         for(int k = 0; k < x128::size; ++k) {
-            vec_sum += expf(static_cast<float>(v1[k]) - thread_max);
-            vec_sum += expf(static_cast<float>(v2[k]) - thread_max);
+            vec_sum += exp2f(static_cast<float>(v1[k]) * kLog2e - log2_thread_max);
+            vec_sum += exp2f(static_cast<float>(v2[k]) * kLog2e - log2_thread_max);
         }
-        thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
+        thread_sum = thread_sum * exp2f(old_maxval * kLog2e - log2_thread_max) + vec_sum;
     }
 
     // now wait for the second half of the data
@@ -136,11 +139,12 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
             float vec_sum = 0.f;
+            float log2_thread_max = thread_max * kLog2e;
             for(int k = 0; k < x128::size; ++k) {
-                vec_sum += expf(static_cast<float>(v1[k]) - thread_max);
-                vec_sum += expf(static_cast<float>(v2[k]) - thread_max);
+                vec_sum += exp2f(static_cast<float>(v1[k]) * kLog2e - log2_thread_max);
+                vec_sum += exp2f(static_cast<float>(v2[k]) * kLog2e - log2_thread_max);
             }
-            thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
+            thread_sum = thread_sum * exp2f(old_maxval * kLog2e - log2_thread_max) + vec_sum;
         }
 
         // epilogue
@@ -153,10 +157,11 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
             float vec_sum = 0.f;
+            float log2_thread_max = thread_max * kLog2e;
             for(int k = 0; k < x128::size; ++k) {
-                vec_sum += expf(static_cast<float>(v[k]) - thread_max);
+                vec_sum += exp2f(static_cast<float>(v[k]) * kLog2e - log2_thread_max);
             }
-            thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
+            thread_sum = thread_sum * exp2f(old_maxval * kLog2e - log2_thread_max) + vec_sum;
         }
     }
 
@@ -206,13 +211,13 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     }
 
     // figure out which warp will encounter the groud-truth token
-    float loss_scale = dloss * scale + z_reg * lse * scale;
+    float shift = (logf((dloss + z_reg * lse) * scale) - cluster_max) * kLog2e;
 
     // treat all classes as if they are negative. This allows us to avoid any conditionals inside this loop.
     for (int i = block_start_ix + threadIdx.x * x128::size; i < block_end_ix; i += x128::size * BLOCK_SIZE) {
         x128 v = x128::load(smem_logits + i - block_start_ix);
         for(int k = 0; k < x128::size; ++k) {
-            float d_logit = expf((float)(v[k]) - cluster_max) * loss_scale;
+            float d_logit = exp2f((float)v[k] * kLog2e + shift);
             v[k] = (floatX)d_logit;
         }
         v.store_cg(logits + i);
@@ -227,7 +232,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     }
     if (threadIdx.x == thread_with_ix) {
         floatX logit = smem_logits[ix - block_start_ix];
-        float loss_neg = expf((float)(logit) - cluster_max) * loss_scale;
+        float loss_neg = exp2f((float)logit * kLog2e + shift);
         logits[ix] = (floatX)(loss_neg - dloss);
     }
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -38,9 +38,9 @@ static __forceinline__ __device__ void reduce_max_4(nv_bfloat16* dst, const nv_b
     }
 }
 
-template<class Float>
-__device__ Float warpReduceMax8(Float val) {
-    for (int offset = 4; offset > 0; offset /= 2) {
+template<int Size, class Float>
+__device__ Float subWarpReduceMax(Float val) {
+    for (int offset = Size/2; offset > 0; offset /= 2) {
         val = dispatch_max(val, __shfl_xor_sync(0xFFFFFFFFu, val, offset));
     }
     return val;
@@ -65,8 +65,8 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
 
     // 1. Initialize shared memory barrier with the number of threads participating in the barrier.
     __shared__ barrier bar;
-    __shared__ floatX max_reduction_buffer[4];
-    __shared__ float sum_reduction_buffer[4];
+    __shared__ floatX max_reduction_buffer[8];
+    __shared__ float sum_reduction_buffer[8];
     extern __shared__ AlignedSmem smem[];
     cg::cluster_group cluster = cg::this_cluster();
 
@@ -152,35 +152,35 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         max_reduction_buffer[threadIdx.x / 32] = warp_max;
     }
     __syncthreads();
-    reduce_max_4(reinterpret_cast<floatX*>(smem), max_reduction_buffer);
-
-    // cluster data exchange for max
-    cluster.sync();
-    const std::byte* remote_mem_ptr;
-    if (threadIdx.x < 8) {
-        remote_mem_ptr = cluster.map_shared_rank(reinterpret_cast<const std::byte*>(smem), threadIdx.x);
-        max_reduction_buffer[threadIdx.x] = reinterpret_cast<const nv_bfloat16*>(remote_mem_ptr)[0];
-    }
-    __syncthreads();
-    floatX cluster_max = warpReduceMax8(max_reduction_buffer[lane_id % 8]);
-
-    thread_sum *= expf(static_cast<float>(thread_max - cluster_max));
+    floatX block_max = subWarpReduceMax<4>(max_reduction_buffer[lane_id % 4]);
+    thread_sum *= expf(static_cast<float>(thread_max - block_max));
     float warp_sum = warpReduceSum(thread_sum);
     if(lane_id == 0) {
         sum_reduction_buffer[threadIdx.x / 32] = warp_sum;
     }
     __syncthreads();
     float block_sum = warpReduceSum(lane_id < 4 ? sum_reduction_buffer[lane_id] : 0.f);
-    if(lane_id == 0) {
+
+    if (threadIdx.x == 0) {
+        reinterpret_cast<floatX*>(smem)[0] = block_max;
         reinterpret_cast<float*>(smem)[1] = block_sum;
     }
+
+    // cluster data exchange
     cluster.sync();
     if (threadIdx.x < 8) {
+        const std::byte* remote_mem_ptr = cluster.map_shared_rank(reinterpret_cast<const std::byte*>(smem), threadIdx.x);
+        max_reduction_buffer[threadIdx.x] = reinterpret_cast<const nv_bfloat16*>(remote_mem_ptr)[0];
         sum_reduction_buffer[threadIdx.x] = reinterpret_cast<const float*>(remote_mem_ptr)[1];
     }
-    cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
     __syncthreads();
-    float cluster_sum = warpReduceSum(lane_id < 8 ? sum_reduction_buffer[lane_id % 8] : 0.f);
+    floatX other_block_max = max_reduction_buffer[lane_id % 8];
+    float other_block_sum = sum_reduction_buffer[lane_id % 8];
+    floatX cluster_max = subWarpReduceMax<8>(other_block_max);
+    other_block_sum *= expf(static_cast<float>(other_block_max - cluster_max));
+    cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
+
+    float cluster_sum = warpReduceSum(lane_id < 8 ? other_block_sum : 0.f);
     float scale = 1.f / cluster_sum;
     float lse = logf(cluster_sum) + (float)cluster_max;
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -38,8 +38,10 @@ __device__ Float subWarpReduceMax(Float val) {
 // uses template to decide whether to write logits and probs
 // split both loops in "multiple-of-x128-size" and "bounds-checked remainder" parts
 template <class floatX>
-//__global__ void __block_size__((1024, 1, 1), (8, 1, 1))
-__global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
+__global__ void
+#if __CUDA_ARCH__ >= 900
+__cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
+#endif
     fused_classifier_tma_kernel(floatX* logits, float* losses, float* lse_out,
                              const float dloss, const int* targets, float z_reg,
                              int V, int P) {
@@ -105,12 +107,13 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     }
     barrier::arrival_token token_b = bar.arrive();
 
-    // hande the first part of the block. By construction, this is a multiple of 2 x128 * block
+    // handle the first part of the block. By construction, this is a multiple of 2 x128 * block
     for (int i = threadIdx.x * x128::size; i < (block_middle_idx - block_start_ix); i += 2 * x128::size * BLOCK_SIZE) {
         x128 v1 = x128::load(smem_logits + i);
         x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
         float old_maxval = thread_max;
         thread_max = static_cast<float>(dispatch_max(vecReduceMax(v1), vecReduceMax(v2)));
+        thread_max = fmaxf(thread_max, old_maxval);
 
         // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
         // FMA, but that costs the same), but could give slightly less rounding error accumulation.
@@ -135,6 +138,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
             x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
             float old_maxval = thread_max;
             thread_max = static_cast<float>(dispatch_max(vecReduceMax(v1), vecReduceMax(v2)));
+            thread_max = fmaxf(thread_max, old_maxval);
 
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
@@ -200,14 +204,17 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     float scale = 1.f / cluster_sum;
     float lse = logf(cluster_sum) + cluster_max;
 
+    // is this block responsible for the ground-truth index
+    bool block_has_ix = block_start_ix <= ix && ix < block_end_ix;
+
     // calculate the probability needed for the loss and update (single-threaded)
     // warp 0 gets all the extra work during reductions, so we let this be handled by warp 1
-    if(threadIdx.x == 32 && block_start_ix < ix && ix < block_end_ix) {
+    if(threadIdx.x == 32 && block_has_ix) {
         losses[idx] -= (float)(smem_logits[ix - block_start_ix]) - lse;
         lse_out[idx] = lse;
     }
 
-    // figure out which warp will encounter the groud-truth token
+    // figure out which warp will encounter the ground-truth token
     float shift = (logf((dloss + z_reg * lse) * scale) - cluster_max) * kLog2e;
 
     // treat all classes as if they are negative. This allows us to avoid any conditionals inside this loop.
@@ -221,8 +228,6 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     }
 
     // write the correct dlogit for the true class
-    // is this block responsible for the ground-truth index
-    bool block_has_ix = block_start_ix < ix && ix < block_end_ix;
     int thread_with_ix = -1;
     if (block_has_ix) {
         thread_with_ix = ((ix - block_start_ix) / x128::size) % BLOCK_SIZE;

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -18,26 +18,6 @@ namespace {
     };
 }
 
-static __forceinline__ __device__ void reduce_max_4(float* dst, const float* smem_src) {
-    if (threadIdx.x < 4) {
-        float val = smem_src[threadIdx.x];
-        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 2));
-        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 1));
-        if (threadIdx.x == 0) {
-            *dst = val;
-        }
-    }
-}
-
-static __forceinline__ __device__ void reduce_max_4(nv_bfloat16* dst, const nv_bfloat16* smem_src) {
-    if(threadIdx.x == 0) {
-        using vec_t = GenericVector<nv_bfloat16, 4>;
-        vec_t val = vec_t::load(smem_src);
-        nv_bfloat162 m = __hmax2(make_bfloat162(val[0], val[1]), make_bfloat162(val[2], val[3]));
-        *dst = __hmax(m.x, m.y);
-    }
-}
-
 template<int Size, class Float>
 __device__ Float subWarpReduceMax(Float val) {
     for (int offset = Size/2; offset > 0; offset /= 2) {
@@ -88,7 +68,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         return;     // mask
     }
     // adjust pointers to point to current token
-    const int logits_per_block = P / 8;
+    const int logits_per_block = V / 8;
     assert(0 <= ix && ix < V);
     __syncthreads();
     int block_start_ix = cluster.block_rank() * logits_per_block;

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -18,24 +18,22 @@ namespace {
     };
 }
 
-static __forceinline__ __device__ void reduce_max_8(float* dst, const float* smem_src) {
-    if (threadIdx.x < 8) {
+static __forceinline__ __device__ void reduce_max_4(float* dst, const float* smem_src) {
+    if (threadIdx.x < 4) {
         float val = smem_src[threadIdx.x];
-        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 4));
-        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 2));
-        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 1));
+        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 2));
+        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 1));
         if (threadIdx.x == 0) {
             *dst = val;
         }
     }
 }
 
-static __forceinline__ __device__ void reduce_max_8(nv_bfloat16* dst, const nv_bfloat16* smem_src) {
-    if (threadIdx.x < 4) {
+static __forceinline__ __device__ void reduce_max_4(nv_bfloat16* dst, const nv_bfloat16* smem_src) {
+    if (threadIdx.x < 2) {
         nv_bfloat162 vals = reinterpret_cast<const nv_bfloat162*>(smem_src)[threadIdx.x];
         nv_bfloat16 val = dispatch_max(vals.x, vals.y);
-        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 2));
-        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 1));
+        val = dispatch_max(val, __shfl_xor_sync(0x00000003u, val, 1));
         if(threadIdx.x == 0) {
             *dst = val;
         }
@@ -50,19 +48,19 @@ static __forceinline__ __device__ void reduce_max_8(nv_bfloat16* dst, const nv_b
 // split both loops in "multiple-of-x128-size" and "bounds-checked remainder" parts
 template <class floatX>
 //__global__ void __block_size__((1024, 1, 1), (8, 1, 1))
-__global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(256, 2)
+__global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     fused_classifier_tma_kernel(floatX* logits, float* losses, float* lse_out,
                              const float dloss, const int* targets, float z_reg,
                              int V, int P) {
     #if __CUDA_ARCH__ >= 900
-    constexpr int BLOCK_SIZE = 256;
+    constexpr int BLOCK_SIZE = 128;
     using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
     using barrier = cuda::barrier<cuda::thread_scope_block>;
 
     // 1. Initialize shared memory barrier with the number of threads participating in the barrier.
     __shared__ barrier bar;
-    __shared__ floatX max_reduction_buffer[8];
-    __shared__ float sum_reduction_buffer[8];
+    __shared__ floatX max_reduction_buffer[4];
+    __shared__ float sum_reduction_buffer[4];
     extern __shared__ AlignedSmem smem[];
     cg::cluster_group cluster = cg::this_cluster();
 
@@ -150,13 +148,14 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(256, 2)
         max_reduction_buffer[threadIdx.x / 32] = warp_max;
     }
     __syncthreads();
-    reduce_max_8(reinterpret_cast<floatX*>(smem), max_reduction_buffer);
+    reduce_max_4(reinterpret_cast<floatX*>(smem), max_reduction_buffer);
 
     // cluster data exchange for max
     cluster.sync();
+    const std::byte* remote_mem_ptr;
     if (threadIdx.x < 8) {
-        const floatX* remote_max = cluster.map_shared_rank(reinterpret_cast<const floatX*>(smem), threadIdx.x);
-        max_reduction_buffer[threadIdx.x] = *remote_max;
+        remote_mem_ptr = cluster.map_shared_rank(reinterpret_cast<const std::byte*>(smem), threadIdx.x);
+        max_reduction_buffer[threadIdx.x] = reinterpret_cast<const nv_bfloat16*>(remote_mem_ptr)[0];
     }
     __syncthreads();
     // TODO faster reduction: we need only 8 values
@@ -168,14 +167,13 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(256, 2)
         sum_reduction_buffer[threadIdx.x / 32] = warp_sum;
     }
     __syncthreads();
-    float block_sum = warpReduceSum(lane_id < 8 ? sum_reduction_buffer[lane_id] : 0.f);
+    float block_sum = warpReduceSum(lane_id < 4 ? sum_reduction_buffer[lane_id] : 0.f);
     if(lane_id == 0) {
         reinterpret_cast<float*>(smem)[1] = block_sum;
     }
     cluster.sync();
     if (threadIdx.x < 8) {
-        const float* remote_sum = cluster.map_shared_rank(reinterpret_cast<const float*>(smem) + 1, threadIdx.x);
-        sum_reduction_buffer[threadIdx.x] = *remote_sum;
+        sum_reduction_buffer[threadIdx.x] = reinterpret_cast<const float*>(remote_mem_ptr)[1];
     }
     cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
     __syncthreads();
@@ -230,7 +228,7 @@ template <typename Type>
 void fused_classifier_tma_imp(Type* logits, float* losses, float* lse,
                              const float dloss, const int* targets, float z_reg,
                              int BT, int V, int P, cudaStream_t stream) {
-    const int block_size = 256;
+    const int block_size = 128;
     const int grid_size = BT * 8;
     const int smem = 128 + P * sizeof(Type) / 8;
     CUDA_CHECK(cudaFuncSetAttribute(fused_classifier_tma_kernel<Type>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem));

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -1,0 +1,230 @@
+// Copyright (c) 2026, IST Austria, developed by Erik Schultheis
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cuda/barrier>
+#include <cooperative_groups.h>
+
+#include "kernel_utils.cuh"
+#include "utilities/utils.h"
+#include "utilities/vec.cuh"
+
+namespace cg = cooperative_groups;
+
+namespace {
+    // dummy struct to imbue dynamic smem with 128 byte alignment
+    struct alignas(128) AlignedSmem  {
+        std::byte content[128];
+    };
+}
+
+static __forceinline__ __device__ void reduce_max_8(float* dst, const float* smem_src) {
+    if (threadIdx.x < 8) {
+        float val = smem_src[threadIdx.x];
+        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 4));
+        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 2));
+        val = dispatch_max(val, __shfl_xor_sync(0x000000FFu, val, 1));
+        if (threadIdx.x == 0) {
+            *dst = val;
+        }
+    }
+}
+
+static __forceinline__ __device__ void reduce_max_8(nv_bfloat16* dst, const nv_bfloat16* smem_src) {
+    if (threadIdx.x < 4) {
+        nv_bfloat162 vals = reinterpret_cast<const nv_bfloat162*>(smem_src)[threadIdx.x];
+        nv_bfloat16 val = dispatch_max(vals.x, vals.y);
+        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 2));
+        val = dispatch_max(val, __shfl_xor_sync(0x0000000Fu, val, 1));
+        if(threadIdx.x == 0) {
+            *dst = val;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// CUDA kernels
+
+// will _update_ logits to logit gradients
+// uses template to decide whether to write logits and probs
+// split both loops in "multiple-of-x128-size" and "bounds-checked remainder" parts
+template <class floatX>
+//__global__ void __block_size__((1024, 1, 1), (8, 1, 1))
+__global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(256, 2)
+    fused_classifier_tma_kernel(floatX* logits, float* losses, float* lse_out,
+                             const float dloss, const int* targets, float z_reg,
+                             int V, int P) {
+    #if __CUDA_ARCH__ >= 900
+    constexpr int BLOCK_SIZE = 256;
+    using x128 = GenericVector<floatX, 16/sizeof(floatX)>;
+    using barrier = cuda::barrier<cuda::thread_scope_block>;
+
+    // 1. Initialize shared memory barrier with the number of threads participating in the barrier.
+    __shared__ barrier bar;
+    __shared__ floatX max_reduction_buffer[8];
+    __shared__ float sum_reduction_buffer[8];
+    extern __shared__ AlignedSmem smem[];
+    cg::cluster_group cluster = cg::this_cluster();
+
+    floatX* smem_logits = reinterpret_cast<floatX*>(reinterpret_cast<std::byte*>(smem) + 128);
+    if (threadIdx.x == 0) {
+        init(&bar, BLOCK_SIZE);
+    }
+
+    // note: idx is small enough that it easily fits into 32 bit;
+    // by making it a long here, we ensure that any offsets calculated with it (e.g., idx * P)
+    // are done is 64 bit
+    int64_t idx = blockIdx.x / 8;
+    int ix = targets[idx];
+    if(ix == -100) {
+        x128 zero = x128::zeros();
+        for (int i = (threadIdx.x + cluster.block_rank() * BLOCK_SIZE) * x128::size; i < P; i += BLOCK_SIZE * 8 * x128::size) {
+            zero.store(logits + idx * P + i);
+        }
+        return;     // mask
+    }
+    // adjust pointers to point to current token
+    const int logits_per_block = P / 8;
+    assert(0 <= ix && ix < V);
+    __syncthreads();
+    int block_start_ix = cluster.block_rank() * logits_per_block;
+    int block_end_ix = block_start_ix + logits_per_block;
+    logits += idx * P;
+
+    if (threadIdx.x == 0) {
+        const int bytes = (block_end_ix - block_start_ix) * sizeof(floatX);
+        cuda::device::memcpy_async_tx(smem_logits, logits + block_start_ix, cuda::aligned_size_t<16>(bytes), bar);
+        cuda::device::barrier_expect_tx(bar, bytes);
+    }
+
+    // 3a. All threads arrive on the barrier.
+    barrier::arrival_token token = bar.arrive();
+
+    floatX thread_max = -INFINITY;
+    float thread_sum = 0.0f;
+    int lane_id = threadIdx.x % 32;
+
+    // 3b. Wait for the data to have arrived.
+    bar.wait(std::move(token));
+
+    // OK, all logits for _this_ block are ready here. Calculate logsumexp
+    for (int i = threadIdx.x * x128::size; i < logits_per_block; i += x128::size * BLOCK_SIZE) {
+        x128 v = x128::load(smem_logits + i);
+        floatX old_maxval = thread_max;
+        for(int k = 0; k < x128::size; ++k) {
+            thread_max = dispatch_max(thread_max, v[k]);
+        }
+        // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
+        // FMA, but that costs the same), but could give slightly less rounding error accumulation.
+        float vec_sum = 0.f;
+        for(int k = 0; k < x128::size; ++k) {
+            vec_sum += expf(static_cast<float>(v[k] - thread_max));
+        }
+        thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
+    }
+
+    floatX warp_max = warpReduceMax(thread_max);
+    if(lane_id == 0) {
+        max_reduction_buffer[threadIdx.x / 32] = warp_max;
+    }
+    __syncthreads();
+    reduce_max_8(reinterpret_cast<floatX*>(smem), max_reduction_buffer);
+
+    // cluster data exchange for max
+    cluster.sync();
+    if (threadIdx.x < 8) {
+        const floatX* remote_max = cluster.map_shared_rank(reinterpret_cast<const floatX*>(smem), threadIdx.x);
+        max_reduction_buffer[threadIdx.x] = *remote_max;
+    }
+    __syncthreads();
+    // TODO faster reduction: we need only 8 values
+    floatX cluster_max = warpReduceMax(max_reduction_buffer[lane_id % 8]);
+
+    thread_sum *= expf(static_cast<float>(thread_max - cluster_max));
+    float warp_sum = warpReduceSum(thread_sum);
+    if(lane_id == 0) {
+        sum_reduction_buffer[threadIdx.x / 32] = warp_sum;
+    }
+    __syncthreads();
+    float block_sum = warpReduceSum(lane_id < 8 ? sum_reduction_buffer[lane_id] : 0.f);
+    if(lane_id == 0) {
+        reinterpret_cast<float*>(smem)[1] = block_sum;
+    }
+    cluster.sync();
+    if (threadIdx.x < 8) {
+        const float* remote_sum = cluster.map_shared_rank(reinterpret_cast<const float*>(smem) + 1, threadIdx.x);
+        sum_reduction_buffer[threadIdx.x] = *remote_sum;
+    }
+    cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
+    __syncthreads();
+    float cluster_sum = warpReduceSum(lane_id < 8 ? sum_reduction_buffer[lane_id % 8] : 0.f);
+    float scale = 1.f / cluster_sum;
+    float lse = logf(cluster_sum) + (float)cluster_max;
+
+    // calculate the probability needed for the loss and update (single-threaded)
+    if(threadIdx.x == 0 && block_start_ix < ix && ix < block_end_ix) {
+        // here, it is important that the subtraction is performed in float precision,
+        // otherwise we can't match the test's required accuracy
+        float prob = expf((float)(logits[ix]) - (float)cluster_max) * scale;
+        losses[idx] -= logf(prob);
+        lse_out[idx] = lse;
+    }
+
+    int ix_by_v = (ix / x128::size) * x128::size;
+    float loss_scale = dloss * scale + z_reg * lse * scale;
+
+    // calculate the gradients directly, saves bandwidth from probs during training
+    // but also supports writing probs for inference-only and debugging
+    for (int i = block_start_ix + threadIdx.x * x128::size; i < block_end_ix; i += x128::size * BLOCK_SIZE) {
+        x128 v = x128::load(smem_logits + i - block_start_ix);
+        if ( i != ix_by_v ) {
+            for(int k = 0; k < x128::size; ++k) {
+                float d_logit = expf((float)(v[k] - cluster_max)) * loss_scale;
+                v[k] = (floatX)d_logit;
+            }
+        } else {
+            for(int k = 0; k < x128::size; ++k) {
+                int element = i + k;
+                float loss_neg = expf((float)(v[k] - cluster_max)) * loss_scale;
+                float indicator = (element == ix) ? 1.0f : 0.0f;
+                v[k] = (floatX)(loss_neg - indicator * dloss);
+            }
+        }
+        // reduce cache persistence for the overwritten logits
+        // to maximise the probability that logits remain in cache between prepare_softmax and here
+        v.store_cs(logits + i);
+    }
+
+    // ensure that no block exits until dsmem communication is done
+    cluster.barrier_wait(std::move(dsmem_done_token));
+    #endif
+}
+
+// ----------------------------------------------------------------------------
+// kernel launchers
+
+// replaces logits with logit gradients
+template <typename Type>
+void fused_classifier_tma_imp(Type* logits, float* losses, float* lse,
+                             const float dloss, const int* targets, float z_reg,
+                             int BT, int V, int P, cudaStream_t stream) {
+    const int block_size = 256;
+    const int grid_size = BT * 8;
+    const int smem = 128 + P * sizeof(Type) / 8;
+    CUDA_CHECK(cudaFuncSetAttribute(fused_classifier_tma_kernel<Type>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem));
+    fused_classifier_tma_kernel<<<grid_size, block_size, smem, stream>>>(
+        logits, losses, lse, dloss, targets, z_reg, V, P);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void fused_classifier_tma(float* logits, float* losses, float* lse,
+                          float dloss, const int* targets, float z_reg,
+                          int BT, int V, int P, cudaStream_t stream) {
+    fused_classifier_tma_imp(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);
+}
+
+void fused_classifier_tma(nv_bfloat16* logits, float* losses, float* lse,
+                          float dloss, const int* targets, float z_reg,
+                          int BT, int V, int P, cudaStream_t stream) {
+    fused_classifier_tma_imp(logits, losses, lse, dloss, targets, z_reg, BT, V, P, stream);
+}

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -17,10 +17,9 @@ namespace {
         std::byte content[128];
     };
 
-    template<typename FloatX>
     struct alignas(8) SoftmaxStats {
         float Sum;
-        FloatX Max;
+        float Max;
     };
 }
 
@@ -51,7 +50,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
 
     // 1. Initialize shared memory barrier with the number of threads participating in the barrier.
     __shared__ barrier bar;
-    __shared__ SoftmaxStats<floatX> reduction_buffer[8];
+    __shared__ SoftmaxStats reduction_buffer[8];
     extern __shared__ AlignedSmem smem[];
     cg::cluster_group cluster = cg::this_cluster();
 
@@ -90,7 +89,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     // 3a. All threads arrive on the barrier.
     barrier::arrival_token token_a = bar.arrive();
 
-    floatX thread_max = -INFINITY;
+    float thread_max = -INFINITY;
     float thread_sum = 0.0f;
     int lane_id = threadIdx.x % 32;
 
@@ -109,17 +108,17 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     for (int i = threadIdx.x * x128::size; i < (block_middle_idx - block_start_ix); i += 2 * x128::size * BLOCK_SIZE) {
         x128 v1 = x128::load(smem_logits + i);
         x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
-        floatX old_maxval = thread_max;
-        thread_max = dispatch_max(vecReduceMax(v1), vecReduceMax(v2));
+        float old_maxval = thread_max;
+        thread_max = static_cast<float>(dispatch_max(vecReduceMax(v1), vecReduceMax(v2)));
 
         // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
         // FMA, but that costs the same), but could give slightly less rounding error accumulation.
         float vec_sum = 0.f;
         for(int k = 0; k < x128::size; ++k) {
-            vec_sum += expf(static_cast<float>(v1[k] - thread_max));
-            vec_sum += expf(static_cast<float>(v2[k] - thread_max));
+            vec_sum += expf(static_cast<float>(v1[k]) - thread_max);
+            vec_sum += expf(static_cast<float>(v2[k]) - thread_max);
         }
-        thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
+        thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
     }
 
     // now wait for the second half of the data
@@ -131,43 +130,43 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         for (; i + x128::size * BLOCK_SIZE < logits_per_block; i += 2 * x128::size * BLOCK_SIZE) {
             x128 v1 = x128::load(smem_logits + i);
             x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
-            floatX old_maxval = thread_max;
-            thread_max = dispatch_max(vecReduceMax(v1), vecReduceMax(v2));
+            float old_maxval = thread_max;
+            thread_max = static_cast<float>(dispatch_max(vecReduceMax(v1), vecReduceMax(v2)));
 
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
             float vec_sum = 0.f;
             for(int k = 0; k < x128::size; ++k) {
-                vec_sum += expf(static_cast<float>(v1[k] - thread_max));
-                vec_sum += expf(static_cast<float>(v2[k] - thread_max));
+                vec_sum += expf(static_cast<float>(v1[k]) - thread_max);
+                vec_sum += expf(static_cast<float>(v2[k]) - thread_max);
             }
-            thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
+            thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
         }
 
         // epilogue
         if (i < logits_per_block) {
             x128 v = x128::load(smem_logits + i);
-            floatX old_maxval = thread_max;
+            float old_maxval = thread_max;
             for(int k = 0; k < x128::size; ++k) {
-                thread_max = dispatch_max(thread_max, v[k]);
+                thread_max = fmaxf(thread_max, static_cast<float>(v[k]));
             }
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
             float vec_sum = 0.f;
             for(int k = 0; k < x128::size; ++k) {
-                vec_sum += expf(static_cast<float>(v[k] - thread_max));
+                vec_sum += expf(static_cast<float>(v[k]) - thread_max);
             }
-            thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
+            thread_sum = thread_sum * expf(old_maxval - thread_max) + vec_sum;
         }
     }
 
-    floatX warp_max = warpReduceMax(thread_max);
+    float warp_max = warpReduceMax(thread_max);
     if(lane_id == 0) {
         reduction_buffer[threadIdx.x / 32].Max = warp_max;
     }
     __syncthreads();
-    floatX block_max = subWarpReduceMax<4>(reduction_buffer[lane_id % 4].Max);
-    thread_sum *= expf(static_cast<float>(thread_max - block_max));
+    float block_max = subWarpReduceMax<4>(reduction_buffer[lane_id % 4].Max);
+    thread_sum *= expf(thread_max - block_max);
     float warp_sum = warpReduceSum(thread_sum);
     if(lane_id == 0) {
         reduction_buffer[threadIdx.x / 32].Sum = warp_sum;
@@ -177,24 +176,24 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
 
     if (threadIdx.x == 0) {
         SoftmaxStats stats{block_sum, block_max};
-        reinterpret_cast<SoftmaxStats<floatX>*>(smem)[0] = stats;
+        reinterpret_cast<SoftmaxStats*>(smem)[0] = stats;
     }
 
     // cluster data exchange
     cluster.sync();
     if (threadIdx.x < 8) {
         const std::byte* remote_mem_ptr = cluster.map_shared_rank(reinterpret_cast<const std::byte*>(smem), threadIdx.x);
-        reduction_buffer[threadIdx.x] = *reinterpret_cast<const SoftmaxStats<floatX>*>(remote_mem_ptr);
+        reduction_buffer[threadIdx.x] = *reinterpret_cast<const SoftmaxStats*>(remote_mem_ptr);
     }
     __syncthreads();
     SoftmaxStats other_stats = reduction_buffer[lane_id % 8];
-    floatX cluster_max = subWarpReduceMax<8>(other_stats.Max);
-    other_stats.Sum *= expf(static_cast<float>(other_stats.Max - cluster_max));
+    float cluster_max = subWarpReduceMax<8>(other_stats.Max);
+    other_stats.Sum *= expf(other_stats.Max - cluster_max);
     cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
 
     float cluster_sum = warpReduceSum(lane_id < 8 ? other_stats.Sum : 0.f);
     float scale = 1.f / cluster_sum;
-    float lse = logf(cluster_sum) + (float)cluster_max;
+    float lse = logf(cluster_sum) + cluster_max;
 
     // calculate the probability needed for the loss and update (single-threaded)
     // warp 0 gets all the extra work during reductions, so we let this be handled by warp 1
@@ -213,7 +212,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     for (int i = block_start_ix + threadIdx.x * x128::size; i < block_end_ix; i += x128::size * BLOCK_SIZE) {
         x128 v = x128::load(smem_logits + i - block_start_ix);
         for(int k = 0; k < x128::size; ++k) {
-            float d_logit = expf((float)(v[k] - cluster_max)) * loss_scale;
+            float d_logit = expf((float)(v[k]) - cluster_max) * loss_scale;
             v[k] = (floatX)d_logit;
         }
         v.store_cg(logits + i);
@@ -228,7 +227,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     }
     if (threadIdx.x == thread_with_ix) {
         floatX logit = smem_logits[ix - block_start_ix];
-        float loss_neg = expf((float)(logit - cluster_max)) * loss_scale;
+        float loss_neg = expf((float)(logit) - cluster_max) * loss_scale;
         logits[ix] = (floatX)(loss_neg - dloss);
     }
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -30,14 +30,20 @@ static __forceinline__ __device__ void reduce_max_4(float* dst, const float* sme
 }
 
 static __forceinline__ __device__ void reduce_max_4(nv_bfloat16* dst, const nv_bfloat16* smem_src) {
-    if (threadIdx.x < 2) {
-        nv_bfloat162 vals = reinterpret_cast<const nv_bfloat162*>(smem_src)[threadIdx.x];
-        nv_bfloat16 val = dispatch_max(vals.x, vals.y);
-        val = dispatch_max(val, __shfl_xor_sync(0x00000003u, val, 1));
-        if(threadIdx.x == 0) {
-            *dst = val;
-        }
+    if(threadIdx.x == 0) {
+        using vec_t = GenericVector<nv_bfloat16, 4>;
+        vec_t val = vec_t::load(smem_src);
+        nv_bfloat162 m = __hmax2(make_bfloat162(val[0], val[1]), make_bfloat162(val[2], val[3]));
+        *dst = __hmax(m.x, m.y);
     }
+}
+
+template<class Float>
+__device__ Float warpReduceMax8(Float val) {
+    for (int offset = 4; offset > 0; offset /= 2) {
+        val = dispatch_max(val, __shfl_xor_sync(0xFFFFFFFFu, val, offset));
+    }
+    return val;
 }
 
 // ----------------------------------------------------------------------------
@@ -112,10 +118,8 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
             x128 v1 = x128::load(smem_logits + i);
             x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
             floatX old_maxval = thread_max;
-            for(int k = 0; k < x128::size; ++k) {
-                floatX m = dispatch_max(v1[k], v2[k]);
-                thread_max = dispatch_max(thread_max, m);
-            }
+            thread_max = dispatch_max(vecReduceMax(v1), vecReduceMax(v2));
+
             // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
             // FMA, but that costs the same), but could give slightly less rounding error accumulation.
             float vec_sum = 0.f;
@@ -158,8 +162,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         max_reduction_buffer[threadIdx.x] = reinterpret_cast<const nv_bfloat16*>(remote_mem_ptr)[0];
     }
     __syncthreads();
-    // TODO faster reduction: we need only 8 values
-    floatX cluster_max = warpReduceMax(max_reduction_buffer[lane_id % 8]);
+    floatX cluster_max = warpReduceMax8(max_reduction_buffer[lane_id % 8]);
 
     thread_sum *= expf(static_cast<float>(thread_max - cluster_max));
     float warp_sum = warpReduceSum(thread_sum);
@@ -182,10 +185,11 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     float lse = logf(cluster_sum) + (float)cluster_max;
 
     // calculate the probability needed for the loss and update (single-threaded)
-    if(threadIdx.x == 0 && block_start_ix < ix && ix < block_end_ix) {
+    // warp 0 gets all the extra work during reductions, so we let this be handled by warp 1
+    if(threadIdx.x == 32 && block_start_ix < ix && ix < block_end_ix) {
         // here, it is important that the subtraction is performed in float precision,
         // otherwise we can't match the test's required accuracy
-        float prob = expf((float)(logits[ix]) - (float)cluster_max) * scale;
+        float prob = expf((float)(smem_logits[ix - block_start_ix]) - (float)cluster_max) * scale;
         losses[idx] -= logf(prob);
         lse_out[idx] = lse;
     }

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -223,29 +223,30 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         lse_out[idx] = lse;
     }
 
-    int ix_by_v = (ix / x128::size) * x128::size;
+    // figure out which warp will encounter the groud-truth token
     float loss_scale = dloss * scale + z_reg * lse * scale;
 
-    // calculate the gradients directly, saves bandwidth from probs during training
-    // but also supports writing probs for inference-only and debugging
+    // treat all classes as if they are negative. This allows us to avoid any conditionals inside this loop.
     for (int i = block_start_ix + threadIdx.x * x128::size; i < block_end_ix; i += x128::size * BLOCK_SIZE) {
         x128 v = x128::load(smem_logits + i - block_start_ix);
-        if ( i != ix_by_v ) {
-            for(int k = 0; k < x128::size; ++k) {
-                float d_logit = expf((float)(v[k] - cluster_max)) * loss_scale;
-                v[k] = (floatX)d_logit;
-            }
-        } else {
-            for(int k = 0; k < x128::size; ++k) {
-                int element = i + k;
-                float loss_neg = expf((float)(v[k] - cluster_max)) * loss_scale;
-                float indicator = (element == ix) ? 1.0f : 0.0f;
-                v[k] = (floatX)(loss_neg - indicator * dloss);
-            }
+        for(int k = 0; k < x128::size; ++k) {
+            float d_logit = expf((float)(v[k] - cluster_max)) * loss_scale;
+            v[k] = (floatX)d_logit;
         }
-        // reduce cache persistence for the overwritten logits
-        // to maximise the probability that logits remain in cache between prepare_softmax and here
-        v.store_cs(logits + i);
+        v.store_cg(logits + i);
+    }
+
+    // write the correct dlogit for the true class
+    // is this block responsible for the ground-truth index
+    bool block_has_ix = block_start_ix < ix && ix < block_end_ix;
+    int thread_with_ix = -1;
+    if (block_has_ix) {
+        thread_with_ix = ((ix - block_start_ix) / x128::size) % BLOCK_SIZE;
+    }
+    if (threadIdx.x == thread_with_ix) {
+        floatX logit = smem_logits[ix - block_start_ix];
+        float loss_neg = expf((float)(logit - cluster_max)) * loss_scale;
+        logits[ix] = (floatX)(loss_neg - dloss);
     }
 
     // ensure that no block exits until dsmem communication is done

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -203,10 +203,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     // calculate the probability needed for the loss and update (single-threaded)
     // warp 0 gets all the extra work during reductions, so we let this be handled by warp 1
     if(threadIdx.x == 32 && block_start_ix < ix && ix < block_end_ix) {
-        // here, it is important that the subtraction is performed in float precision,
-        // otherwise we can't match the test's required accuracy
-        float prob = expf((float)(smem_logits[ix - block_start_ix]) - (float)cluster_max) * scale;
-        losses[idx] -= logf(prob);
+        losses[idx] -= (float)(smem_logits[ix - block_start_ix]) - lse;
         lse_out[idx] = lse;
     }
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -92,28 +92,57 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     assert(0 <= ix && ix < V);
     __syncthreads();
     int block_start_ix = cluster.block_rank() * logits_per_block;
+    int block_middle_idx = round_down(block_start_ix + logits_per_block / 2, 2 * x128::size * BLOCK_SIZE);
     int block_end_ix = block_start_ix + logits_per_block;
     logits += idx * P;
 
     if (threadIdx.x == 0) {
-        const int bytes = (block_end_ix - block_start_ix) * sizeof(floatX);
+        const int bytes = (block_middle_idx - block_start_ix) * sizeof(floatX);
         cuda::device::memcpy_async_tx(smem_logits, logits + block_start_ix, cuda::aligned_size_t<16>(bytes), bar);
         cuda::device::barrier_expect_tx(bar, bytes);
     }
 
     // 3a. All threads arrive on the barrier.
-    barrier::arrival_token token = bar.arrive();
+    barrier::arrival_token token_a = bar.arrive();
 
     floatX thread_max = -INFINITY;
     float thread_sum = 0.0f;
     int lane_id = threadIdx.x % 32;
 
     // 3b. Wait for the data to have arrived.
-    bar.wait(std::move(token));
+    bar.wait(std::move(token_a));
 
-    // OK, all logits for _this_ block are ready here. Calculate logsumexp
+    // start the rest of the transfer
+    if (threadIdx.x == 0) {
+        const int bytes = (block_end_ix - block_middle_idx) * sizeof(floatX);
+        cuda::device::memcpy_async_tx(smem_logits + (block_middle_idx - block_start_ix), logits + block_middle_idx, cuda::aligned_size_t<16>(bytes), bar);
+        cuda::device::barrier_expect_tx(bar, bytes);
+    }
+    barrier::arrival_token token_b = bar.arrive();
+
+    // hande the first part of the block. By construction, this is a multiple of 2 x128 * block
+    for (int i = threadIdx.x * x128::size; i < (block_middle_idx - block_start_ix); i += 2 * x128::size * BLOCK_SIZE) {
+        x128 v1 = x128::load(smem_logits + i);
+        x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
+        floatX old_maxval = thread_max;
+        thread_max = dispatch_max(vecReduceMax(v1), vecReduceMax(v2));
+
+        // write this as a two-level reduction. this does not require any additional instructions (we change FMUL to
+        // FMA, but that costs the same), but could give slightly less rounding error accumulation.
+        float vec_sum = 0.f;
+        for(int k = 0; k < x128::size; ++k) {
+            vec_sum += expf(static_cast<float>(v1[k] - thread_max));
+            vec_sum += expf(static_cast<float>(v2[k] - thread_max));
+        }
+        thread_sum = thread_sum * expf(static_cast<float>(old_maxval - thread_max)) + vec_sum;
+    }
+
+    // now wait for the second half of the data
+    bar.wait(std::move(token_b));
+
+    // Now handle the rest. This might be not a multiple of block_size * 2 * x128, so we have an epilogue
     {
-        int i = threadIdx.x * x128::size;
+        int i = (block_middle_idx - block_start_ix) + threadIdx.x * x128::size;
         for (; i + x128::size * BLOCK_SIZE < logits_per_block; i += 2 * x128::size * BLOCK_SIZE) {
             x128 v1 = x128::load(smem_logits + i);
             x128 v2 = x128::load(smem_logits + i + x128::size * BLOCK_SIZE);
@@ -131,7 +160,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
         }
 
         // epilogue
-        if (i  < logits_per_block) {
+        if (i < logits_per_block) {
             x128 v = x128::load(smem_logits + i);
             floatX old_maxval = thread_max;
             for(int k = 0; k < x128::size; ++k) {

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -16,6 +16,12 @@ namespace {
     struct alignas(128) AlignedSmem  {
         std::byte content[128];
     };
+
+    template<typename FloatX>
+    struct alignas(8) SoftmaxStats {
+        float Sum;
+        FloatX Max;
+    };
 }
 
 template<int Size, class Float>
@@ -45,8 +51,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
 
     // 1. Initialize shared memory barrier with the number of threads participating in the barrier.
     __shared__ barrier bar;
-    __shared__ floatX max_reduction_buffer[8];
-    __shared__ float sum_reduction_buffer[8];
+    __shared__ SoftmaxStats<floatX> reduction_buffer[8];
     extern __shared__ AlignedSmem smem[];
     cg::cluster_group cluster = cg::this_cluster();
 
@@ -72,7 +77,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     assert(0 <= ix && ix < V);
     __syncthreads();
     int block_start_ix = cluster.block_rank() * logits_per_block;
-    int block_middle_idx = round_down(block_start_ix + logits_per_block / 2, 2 * x128::size * BLOCK_SIZE);
+    int block_middle_idx = round_down(block_start_ix + logits_per_block / 2, static_cast<int>(2 * x128::size * BLOCK_SIZE));
     int block_end_ix = block_start_ix + logits_per_block;
     logits += idx * P;
 
@@ -158,38 +163,36 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
 
     floatX warp_max = warpReduceMax(thread_max);
     if(lane_id == 0) {
-        max_reduction_buffer[threadIdx.x / 32] = warp_max;
+        reduction_buffer[threadIdx.x / 32].Max = warp_max;
     }
     __syncthreads();
-    floatX block_max = subWarpReduceMax<4>(max_reduction_buffer[lane_id % 4]);
+    floatX block_max = subWarpReduceMax<4>(reduction_buffer[lane_id % 4].Max);
     thread_sum *= expf(static_cast<float>(thread_max - block_max));
     float warp_sum = warpReduceSum(thread_sum);
     if(lane_id == 0) {
-        sum_reduction_buffer[threadIdx.x / 32] = warp_sum;
+        reduction_buffer[threadIdx.x / 32].Sum = warp_sum;
     }
     __syncthreads();
-    float block_sum = warpReduceSum(lane_id < 4 ? sum_reduction_buffer[lane_id] : 0.f);
+    float block_sum = warpReduceSum(lane_id < 4 ? reduction_buffer[lane_id].Sum : 0.f);
 
     if (threadIdx.x == 0) {
-        reinterpret_cast<floatX*>(smem)[0] = block_max;
-        reinterpret_cast<float*>(smem)[1] = block_sum;
+        SoftmaxStats stats{block_sum, block_max};
+        reinterpret_cast<SoftmaxStats<floatX>*>(smem)[0] = stats;
     }
 
     // cluster data exchange
     cluster.sync();
     if (threadIdx.x < 8) {
         const std::byte* remote_mem_ptr = cluster.map_shared_rank(reinterpret_cast<const std::byte*>(smem), threadIdx.x);
-        max_reduction_buffer[threadIdx.x] = reinterpret_cast<const nv_bfloat16*>(remote_mem_ptr)[0];
-        sum_reduction_buffer[threadIdx.x] = reinterpret_cast<const float*>(remote_mem_ptr)[1];
+        reduction_buffer[threadIdx.x] = *reinterpret_cast<const SoftmaxStats<floatX>*>(remote_mem_ptr);
     }
     __syncthreads();
-    floatX other_block_max = max_reduction_buffer[lane_id % 8];
-    float other_block_sum = sum_reduction_buffer[lane_id % 8];
-    floatX cluster_max = subWarpReduceMax<8>(other_block_max);
-    other_block_sum *= expf(static_cast<float>(other_block_max - cluster_max));
+    SoftmaxStats other_stats = reduction_buffer[lane_id % 8];
+    floatX cluster_max = subWarpReduceMax<8>(other_stats.Max);
+    other_stats.Sum *= expf(static_cast<float>(other_stats.Max - cluster_max));
     cg::cluster_group::arrival_token dsmem_done_token = cluster.barrier_arrive();
 
-    float cluster_sum = warpReduceSum(lane_id < 8 ? other_block_sum : 0.f);
+    float cluster_sum = warpReduceSum(lane_id < 8 ? other_stats.Sum : 0.f);
     float scale = 1.f / cluster_sum;
     float lse = logf(cluster_sum) + (float)cluster_max;
 

--- a/src/kernels/fused_classifier_tma.cu
+++ b/src/kernels/fused_classifier_tma.cu
@@ -77,7 +77,7 @@ __global__ void __cluster_dims__(8, 1, 1) __launch_bounds__(128, 2)
     assert(0 <= ix && ix < V);
     __syncthreads();
     int block_start_ix = cluster.block_rank() * logits_per_block;
-    int block_middle_idx = round_down(block_start_ix + logits_per_block / 2, static_cast<int>(2 * x128::size * BLOCK_SIZE));
+    int block_middle_idx = block_start_ix + round_down(logits_per_block / 2, static_cast<int>(2 * x128::size * BLOCK_SIZE));
     int block_end_ix = block_start_ix + logits_per_block;
     logits += idx * P;
 

--- a/src/kernels/kernel_utils.cuh
+++ b/src/kernels/kernel_utils.cuh
@@ -48,9 +48,18 @@ static __forceinline__ __device__ float warpReduceSum(float val) {
     return val;
 }
 
-__device__ inline float warpReduceMax(float val) {
+static __forceinline__ __device__ nv_bfloat16 dispatch_max(nv_bfloat16 a, nv_bfloat16 b) {
+    return __hmax(a, b);
+}
+
+static __forceinline__ __device__ float dispatch_max(float a, float b) {
+    return fmaxf(a, b);
+}
+
+template<class Float>
+__device__ Float warpReduceMax(Float val) {
     for (int offset = 16; offset > 0; offset /= 2) {
-        val = fmaxf(val, __shfl_xor_sync(0xFFFFFFFFu, val, offset));
+        val = dispatch_max(val, __shfl_xor_sync(0xFFFFFFFFu, val, offset));
     }
     return val;
 }

--- a/src/utilities/utils.h
+++ b/src/utilities/utils.h
@@ -41,6 +41,11 @@ constexpr T HOST_DEVICE div_ceil(T dividend, T divisor) {
     return (dividend + divisor - 1) / divisor;
 }
 
+template<std::integral T>
+constexpr T HOST_DEVICE round_down(T dividend, T divisor) {
+    return (dividend / divisor) * divisor;
+}
+
 [[noreturn]] void throw_not_divisible(long long dividend, long long divisor);
 
 template<std::integral T>


### PR DESCRIPTION
On datacenter Blackwell and Hopper cards, use a TMA + DSMEM-based implementation for the fused classifier kernel.