### PR TITLE
CLI improvements

### DIFF
--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -439,11 +439,11 @@ NB_MODULE(_pyllmq, m) {
         .def("log_dataset", &TrainingRunLogger::log_dataset, nb::arg("train_loader"), nb::arg("eval_loader"),
              "Log dataset information")
         .def("log_step", &TrainingRunLogger::log_step,
-             nb::arg("step"), nb::arg("epoch"), nb::arg("step_tokens"), nb::arg("duration_ms"),
+             nb::arg("step"), nb::arg("step_tokens"), nb::arg("duration_ms"),
              nb::arg("norm"), nb::arg("loss"), nb::arg("logit_lse_max"), nb::arg("logit_lse_mean"), nb::arg("lr"),
              "Log a training step")
         .def("log_eval", &TrainingRunLogger::log_eval,
-             nb::arg("step"), nb::arg("epoch"), nb::arg("eval_tokens"), nb::arg("duration_ms"), nb::arg("loss"),
+             nb::arg("step"), nb::arg("eval_tokens"), nb::arg("duration_ms"), nb::arg("loss"),
              "Log an evaluation step")
         .def("log_gpu_state", &TrainingRunLogger::log_gpu_state,
              nb::arg("step"), nb::arg("gpu_id"), nb::arg("gpu_util"),

--- a/src/training/logging.cpp
+++ b/src/training/logging.cpp
@@ -143,18 +143,19 @@ std::string format_time(int duration_ms) {
     }
 }
 
-void TrainingRunLogger::log_step(int step, float epoch, int step_tokens, int duration_ms, float norm, float loss, float logit_lse_max, float logit_lse_mean, float lr)
+void TrainingRunLogger::log_step(int step, int step_tokens, int duration_ms, float norm, float loss, float logit_lse_max, float logit_lse_mean, float lr)
 {
     if(mRank != 0) return;
     mTotalTrainingLoss += loss;
     ++mTotalTrainingSteps;
 
     if(mVerbosity >= 0) {
-        float iptr;
-        float progress = 100.f * std::modf(epoch,  &iptr);
         std::string tps_msg = format_tps(step_tokens, duration_ms);
         std::string time_str = format_time(duration_ms);
         std::string sol_msg = "";
+        float progress = 0.f;
+        if (mFinalStep > 0)
+            progress = 100.f * step / static_cast<float>(mFinalStep);
 
         // speed-of-light
         if (mExpectedTimePerToken > 0) {
@@ -163,29 +164,30 @@ void TrainingRunLogger::log_step(int step, float epoch, int step_tokens, int dur
             sol_msg = fmt::format(" | sol {:.1f}%", ratio * 100.0);
         }
 
-        printf("[T] step %5d [%5.1f%%] | time: %s | norm %10f | loss %10f | tps %s%s\n", step, progress, time_str.c_str(), norm, loss, tps_msg.c_str(), sol_msg.c_str());
+        printf("[T] step %5d [%4.1f%%] | time: %s | norm %10f | loss %10f | tps %s%s\n", step, progress, time_str.c_str(), norm, loss, tps_msg.c_str(), sol_msg.c_str());
         fflush(stdout);
     }
-    log_line(fmt::format(R"(  {{"log": "step", "time": "{}", "step": {}, "epoch": {}, "step_tokens": {}, "duration_ms": {}, "norm": {}, "loss": {}, "lr": {}, "lse_max": {}, "lse_mean": {}}})",
-        std::chrono::system_clock::now(), step, epoch, step_tokens, duration_ms, norm, loss, lr, logit_lse_max, logit_lse_mean ));
+    log_line(fmt::format(R"(  {{"log": "step", "time": "{}", "step": {}, "step_tokens": {}, "duration_ms": {}, "norm": {}, "loss": {}, "lr": {}, "lse_max": {}, "lse_mean": {}}})",
+        std::chrono::system_clock::now(), step, step_tokens, duration_ms, norm, loss, lr, logit_lse_max, logit_lse_mean ));
 }
 
-void TrainingRunLogger::log_eval(int step, float epoch, int eval_tokens, int duration_ms, float loss)
+void TrainingRunLogger::log_eval(int step, int eval_tokens, int duration_ms, float loss)
 {
     if(mRank != 0) return;
     if(mVerbosity >= -1) {
-        float iptr;
-        float progress = 100.f * std::modf(epoch,  &iptr);
+        float progress = 0.f;
+        if (mFinalStep > 0)
+            progress = 100.f * step / static_cast<float>(mFinalStep);
         float train_avg = static_cast<float>(mTotalTrainingLoss / std::max(mTotalTrainingSteps, 1));
         std::string tps_msg = format_tps(eval_tokens, duration_ms);
         std::string time_str = format_time(duration_ms);
-        printf("\x1b[1m[V] step %5d [%5.1f%%] | time: %s | eval %10f | train %9f | tps %s\x1b[22m\n", step, progress, time_str.c_str(), loss, train_avg, tps_msg.c_str());
+        printf("\x1b[1m[V] step %5d [%4.1f%%] | time: %s | eval %10f | train %9f | tps %s\x1b[22m\n", step, progress, time_str.c_str(), loss, train_avg, tps_msg.c_str());
         fflush(stdout);
     }
     mTotalTrainingLoss = 0;
     mTotalTrainingSteps = 0;
-    log_line(fmt::format(R"(  {{"log": "eval", "time": "{}", "step": {}, "epoch": {}, "eval_tokens": {}, "duration_ms": {}, "loss": {}}})",
-        std::chrono::system_clock::now(), step, epoch, eval_tokens, duration_ms, loss ));
+    log_line(fmt::format(R"(  {{"log": "eval", "time": "{}", "step": {}, "eval_tokens": {}, "duration_ms": {}, "loss": {}}})",
+        std::chrono::system_clock::now(), step, eval_tokens, duration_ms, loss ));
 }
 
 void TrainingRunLogger::log_gpu_state(int step, int gpu_id, const GPUUtilInfo& gpu_util)
@@ -417,6 +419,10 @@ void TrainingRunLogger::log_abs_maxes(int step, const std::vector<std::pair<std:
 
 void TrainingRunLogger::set_callback(std::function<void(std::string_view)> cb) {
     mCallback = std::move(cb);
+}
+
+void TrainingRunLogger::set_final_step(int step) {
+    mFinalStep = step;
 }
 
 void TrainingRunLogger::log_message(int step, const std::string& msg) {

--- a/src/training/logging.h
+++ b/src/training/logging.h
@@ -35,13 +35,14 @@ public:
 
     void log_sol_estimate(std::vector<std::pair<ETensorDType, long>> ops, int world_size);
     void set_callback(std::function<void(std::string_view)> cb);
+    void set_final_step(int step);
 
     void log_cmd(int argc, const char** argv);
     void log_options(const std::vector<std::pair<std::string_view, std::variant<bool, std::int64_t, float, std::string>>>& options);
     void log_gpu_model(NCCLCommunicator& comm);
     void log_dataset(const DataLoader& train_loader, const DataLoader& eval_loader);
-    void log_step(int step, float epoch, int step_tokens, int duration_ms, float norm, float loss, float logit_lse_max, float logit_lse_mean, float lr);
-    void log_eval(int step, float epoch, int eval_tokens, int duration_ms, float loss);
+    void log_step(int step, int step_tokens, int duration_ms, float norm, float loss, float logit_lse_max, float logit_lse_mean, float lr);
+    void log_eval(int step, int eval_tokens, int duration_ms, float loss);
     void log_gpu_state(int step, int gpu_id, const GPUUtilInfo& gpu_util);
     void log_allocator(
         const std::vector<std::pair<std::string, sSegmentMemory>>& stats,
@@ -84,7 +85,7 @@ private:
     int mTotalTrainingSteps = 0;
 
     // to estimate ETA
-    int mRemainingTokens = -1;
+    int mFinalStep = -1;
 
     // to estimate MFU
     long mExpectedTimePerToken = -1;

--- a/train.cpp
+++ b/train.cpp
@@ -87,7 +87,7 @@ struct TrainingRunner {
     int MajorCkptEvery = -1;
     int LogGPUEvery = 25;
 
-    std::optional<int> ContinueFromCheckpoint;
+    std::optional<std::string> ContinueFromCheckpoint;
 
     int NGPUs = 0;
     bool MemcpyAllGather = false;
@@ -167,8 +167,8 @@ void TrainingRunner::load_training_config(int argc, const char** argv) {
     app.add_option("--ckpt-interval", CkptEvery, "How many optimizer steps between checkpoints");
     app.add_option("--ckpt-keep-n", CkptToKeep, "Clean up old checkpoints, only preserving the latest n.");
     app.add_option("--ckpt-major", MajorCkptEvery, "Make every nth checkpoint a major checkpoint, which does not get cleaned up.");
-    auto continue_from_checkpoint = app.add_option("--continue", ContinueFromCheckpoint,
-        "Continue from checkpoint. If no number is given, uses the latest checkpoint")->expected(0, 1)->default_str("-1");
+    app.add_option("--continue", ContinueFromCheckpoint,
+        "Continue from checkpoint. If no argument is given, continue from the latest checkpoint in the current run.")->expected(0, 1)->default_str("");
 
     app.add_option("--log-file", LogFile, "Where to save the training log");
     app.add_option("--gpus", NGPUs, "How many GPUs to use for training.");
@@ -436,14 +436,31 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
 
 
     int latest_step = -1;
+    std::string load_ckp_from;
     if (ContinueFromCheckpoint.has_value()) {
-        if (ContinueFromCheckpoint.value() < 0) {
+        if (ContinueFromCheckpoint->empty()) {
             latest_step = find_latest_checkpoint(CkptDir);
+            load_ckp_from = CkptDir;
         } else {
-            latest_step = ContinueFromCheckpoint.value();
+            std::string arg_value = ContinueFromCheckpoint.value();
+            char* ptr;
+            long arg_value_long = strtol(arg_value.c_str(), &ptr, 10);
+            if (ptr == arg_value.c_str() + arg_value.size() && arg_value_long >= 0) {
+                latest_step = arg_value_long;
+                load_ckp_from = CkptDir;
+            } else {
+                std::string dir_name = std::filesystem::path(ContinueFromCheckpoint.value()).filename().string();
+                if (dir_name.starts_with("step_")) {
+                    latest_step = std::stoi(dir_name.substr(5));
+                    load_ckp_from = std::filesystem::path(ContinueFromCheckpoint.value()).parent_path().string();
+                } else {
+                    latest_step = find_latest_checkpoint(ContinueFromCheckpoint.value());
+                    load_ckp_from = ContinueFromCheckpoint.value();
+                }
+            }
         }
         if (latest_step < 0) {
-            std::cerr << "No checkpoint found in " << CkptDir << std::endl;
+            std::cerr << "No checkpoint found in " << load_ckp_from << std::endl;
             std::cerr << " starting from scratch" << std::endl;
         }
     }
@@ -451,8 +468,8 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
     model.allocate_run_state(Options, comm, B, T);
 
     if (latest_step >= 0) {
-        auto log = logger.log_section_start(0, fmt::format("Loading checkpoint {} from `{}`", latest_step, CkptDir.c_str()));
-        load_checkpoint(CkptDir, latest_step, model, &train_loader, comm);
+        auto log = logger.log_section_start(0, fmt::format("Loading checkpoint {} from `{}`", latest_step, load_ckp_from.c_str()));
+        load_checkpoint(load_ckp_from, latest_step, model, &train_loader, comm);
     } else if (FromScratch) {
         auto log = logger.log_section_start(0, "Initializing model from scratch");
         model.init_weights(comm);

--- a/train.cpp
+++ b/train.cpp
@@ -21,7 +21,7 @@
 #include <CLI/CLI.hpp>
 #include <fmt/chrono.h>
 
-float run_evaluation(DataLoader& test_loader, LLamaModel& model, TrainingRunLogger& logger, float epoch, int step,
+float run_evaluation(DataLoader& test_loader, LLamaModel& model, TrainingRunLogger& logger, int step,
                      NCCLCommunicator& comm, int max_steps, Tensor& inputs, Tensor& targets);
 
 bool lexical_cast(const std::string& input, ETensorDType& output) {
@@ -323,6 +323,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
     if (MaxSteps == -1) {
         MaxSteps = steps_per_epoch * NumEpochs;
     }
+    logger.set_final_step(MaxSteps);
 
     logger.log_options({
         {"name",               RunName},
@@ -507,7 +508,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
         }
 
         if (run_eval) {
-            run_evaluation(test_loader, model, logger, train_loader.epoch() + 0.01f * train_loader.progress(), step, comm, EvalNumSteps,
+            run_evaluation(test_loader, model, logger, step, comm, EvalNumSteps,
                            inputs, targets);
         }
 
@@ -547,7 +548,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
             logger.log_message(step, fmt::format("Gradient norm outlier with z-score: {}", grad_z));
         }
 
-        logger.log_step(step, train_loader.epoch() + 0.01f*train_loader.progress(), B*T*GradAccSteps*comm.world_size(),
+        logger.log_step(step, B*T*GradAccSteps*comm.world_size(),
             narrow<int>(ms), step_norm, step_loss / (B*T*GradAccSteps), logit_lse_max, logit_lse_mean, lr);
 
         if (DebugLogAbsMaxes > 0 && step % DebugLogAbsMaxes == 0) {
@@ -564,7 +565,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
         }
     }
 
-    float loss = run_evaluation(test_loader, model, logger, train_loader.epoch() + 0.01f*train_loader.progress(), MaxSteps, comm, test_loader.num_chunks(), inputs, targets);
+    float loss = run_evaluation(test_loader, model, logger, MaxSteps, comm, test_loader.num_chunks(), inputs, targets);
     logger.log_message(MaxSteps, fmt::format("Done. validation loss {:10f}", loss));
 
     auto log = logger.log_section_start(MaxSteps, fmt::format("Saving model to `{}`", OutDir.c_str()));
@@ -594,7 +595,7 @@ void TrainingRunner::run_training(int argc, const char** argv, NCCLCommunicator&
     }
 }
 
-float run_evaluation(DataLoader& test_loader, LLamaModel& model, TrainingRunLogger& logger, float epoch, int step,
+float run_evaluation(DataLoader& test_loader, LLamaModel& model, TrainingRunLogger& logger, int step,
                      NCCLCommunicator& comm, int max_steps, Tensor& inputs, Tensor& targets) {
     NvtxRange range("validate", step);
     std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
@@ -615,7 +616,7 @@ float run_evaluation(DataLoader& test_loader, LLamaModel& model, TrainingRunLogg
     }
     std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
     long ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    logger.log_eval(step, epoch, batches * targets.nelem(), narrow<int>(ms), loss / batches);
+    logger.log_eval(step, batches * targets.nelem(), narrow<int>(ms), loss / batches);
     return loss / batches;
 }
 


### PR DESCRIPTION
Add the ability to continue from a checkpoint with a different name than the current training run.
Remove "epoch" data from logging, it isn't really useful and won't generalize well once we add data mixtures.