### PR TITLE
Bound NCCL communicator teardown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,4 +265,11 @@ if (BUILD_TESTS)
     target_compile_options(unit-tests PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>)
 
     add_test(NAME unit-tests COMMAND unit-tests)
-endif ()
+
+    if (Threads_FOUND)
+        add_executable(bounded-cleanup-tests src/testing/test-bounded-cleanup.cpp)
+        target_include_directories(bounded-cleanup-tests PRIVATE src)
+        target_link_libraries(bounded-cleanup-tests PRIVATE Threads::Threads)
+        add_test(NAME bounded-cleanup-tests COMMAND bounded-cleanup-tests)
+    endif ()
+  endif ()

--- a/src/testing/test-bounded-cleanup.cpp
+++ b/src/testing/test-bounded-cleanup.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+
+#include "utilities/bounded_cleanup.h"
+
+using namespace std::chrono_literals;
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void test_timed_out_cleanup_retains_exclusive_state_without_blocking_owner() {
+    struct Resource {
+        std::shared_ptr<std::atomic<int>> destructions;
+
+        explicit Resource(std::shared_ptr<std::atomic<int>> value) : destructions(std::move(value)) {}
+
+        ~Resource() {
+            ++*destructions;
+        }
+    };
+    struct State {
+        std::unique_ptr<Resource> resource;
+        std::shared_ptr<std::atomic<bool>> owner_alive;
+        std::shared_ptr<std::atomic<bool>> observed_dead_owner;
+        std::shared_future<void> release;
+        std::shared_ptr<std::promise<void>> completed;
+    };
+
+    auto owner_alive = std::make_shared<std::atomic<bool>>(true);
+    auto observed_dead_owner = std::make_shared<std::atomic<bool>>(false);
+    auto destructions = std::make_shared<std::atomic<int>>(0);
+    auto release = std::make_shared<std::promise<void>>();
+    auto completed = std::make_shared<std::promise<void>>();
+    auto completion = completed->get_future();
+    const auto started = std::chrono::steady_clock::now();
+
+    const auto outcome = run_bounded_cleanup(
+        State{std::make_unique<Resource>(destructions), owner_alive,
+              observed_dead_owner, release->get_future().share(), completed},
+        [](State state) mutable {
+            state.release.wait();
+            state.observed_dead_owner->store(!state.owner_alive->load());
+            state.resource.reset();
+            state.completed->set_value();
+        },
+        20ms);
+    owner_alive->store(false);
+
+    require(outcome == BoundedCleanupOutcome::TimedOut, "cleanup did not time out");
+    require(std::chrono::steady_clock::now() - started < 500ms, "cleanup blocked its owner");
+    release->set_value();
+    require(completion.wait_for(500ms) == std::future_status::ready, "detached cleanup did not finish");
+    require(observed_dead_owner->load(), "cleanup observed live owner state after timeout");
+    require(destructions->load() == 1, "timed-out resource was not destroyed exactly once");
+}
+
+void test_completed_cleanup_joins_before_returning() {
+    auto cleaned = std::make_shared<std::atomic<int>>(0);
+    const auto outcome = run_bounded_cleanup(
+        cleaned,
+        [](const std::shared_ptr<std::atomic<int>>& value) { ++*value; },
+        500ms);
+
+    require(outcome == BoundedCleanupOutcome::Completed, "completed cleanup reported timeout");
+    require(cleaned->load() == 1, "cleanup returned before completion");
+}
+
+int main() {
+    try {
+        test_timed_out_cleanup_retains_exclusive_state_without_blocking_owner();
+        test_completed_cleanup_joins_before_returning();
+        std::cout << "bounded cleanup tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "bounded cleanup test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/src/utilities/bounded_cleanup.h
+++ b/src/utilities/bounded_cleanup.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef LLMQ_SRC_UTILITIES_BOUNDED_CLEANUP_H
+#define LLMQ_SRC_UTILITIES_BOUNDED_CLEANUP_H
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <utility>
+
+enum class BoundedCleanupOutcome {
+    Completed,
+    TimedOut,
+};
+
+template<class State, class Cleanup>
+BoundedCleanupOutcome run_bounded_cleanup(
+        State state,
+        Cleanup cleanup,
+        std::chrono::milliseconds timeout) {
+    auto completed = std::make_shared<std::atomic<bool>>(false);
+    std::thread worker(
+        [state = std::move(state), cleanup = std::move(cleanup), completed]() mutable {
+            cleanup(std::move(state));
+            completed->store(true, std::memory_order_release);
+        });
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!completed->load(std::memory_order_acquire)
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (completed->load(std::memory_order_acquire)) {
+        worker.join();
+        return BoundedCleanupOutcome::Completed;
+    }
+    worker.detach();
+    return BoundedCleanupOutcome::TimedOut;
+}
+
+#endif

--- a/src/utilities/comm.cpp
+++ b/src/utilities/comm.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "comm.h"
+#include "bounded_cleanup.h"
 
 #include <stdexcept>
 #include <utility>
@@ -70,35 +71,42 @@ NCCLCommunicator::NCCLCommunicator(int rank, int world, const void* nccl_id) :
 #include <pthread.h>
 
 NCCLCommunicator::~NCCLCommunicator() {
-    // When used with the python bindings, ncclCommFinalize() can hang forever;
-    // I haven't found a fix, so here we just make sure that the hang gets localized
-    // to a helper thread (which we leak, but generally ~NCCLCommunicator is expected
-    // to run at program shutdown anyway)
-    auto terminate_future = std::async(std::launch::async, [this]() {
-        this->terminate_nccl();
-    });
+    struct CleanupState {
+        ncclComm_t comm;
+        cudaEvent_t sync;
+        cudaStream_t stream;
+        bool clean_exit;
+    };
+    CleanupState state{mNcclComm, mCommsSync, mCommsStream, std::uncaught_exceptions() == 0};
+    mNcclComm = nullptr;
+    mCommsSync = nullptr;
+    mCommsStream = nullptr;
 
-    if (terminate_future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-        fprintf(stderr, "NCCL termination timed out, detaching\n");
-        // this *will* leak resources, but at least we're not hanging forever
-        new auto(std::move(terminate_future));
-    }
-    CUDA_CHECK(cudaEventDestroy(mCommsSync));
-    CUDA_CHECK(cudaStreamDestroy(mCommsStream));
-}
-
-void NCCLCommunicator::terminate_nccl() {
-    ncclResult_t result;
-    ncclCheck(ncclCommGetAsyncError(mNcclComm, &result));
-    // do "nice" shutdown if we're in a good state,
-    // just abort if there is something weird going on.
-    if (std::uncaught_exceptions() == 0 && result == ncclSuccess) {
-        CUDA_CHECK(cudaStreamSynchronize(mCommsStream));
-        CUDA_CHECK(cudaDeviceSynchronize());
-        ncclCheck(ncclCommFinalize(mNcclComm));
-        ncclCheck(ncclCommDestroy(mNcclComm));
-    } else {
-        ncclCheck(ncclCommAbort(mNcclComm));
+    const auto outcome = run_bounded_cleanup(
+        state,
+        [](CleanupState owned) {
+            try {
+                ncclResult_t result;
+                ncclCheck(ncclCommGetAsyncError(owned.comm, &result));
+                if (owned.clean_exit && result == ncclSuccess) {
+                    CUDA_CHECK(cudaStreamSynchronize(owned.stream));
+                    CUDA_CHECK(cudaDeviceSynchronize());
+                    ncclCheck(ncclCommFinalize(owned.comm));
+                    ncclCheck(ncclCommDestroy(owned.comm));
+                } else {
+                    ncclCheck(ncclCommAbort(owned.comm));
+                }
+                CUDA_CHECK(cudaEventDestroy(owned.sync));
+                CUDA_CHECK(cudaStreamDestroy(owned.stream));
+            } catch (const std::exception& error) {
+                fprintf(stderr, "NCCL termination failed: %s\n", error.what());
+                fflush(stderr);
+            }
+        },
+        std::chrono::seconds(2));
+    if (outcome == BoundedCleanupOutcome::TimedOut) {
+        fprintf(stderr, "NCCL termination timed out; cleanup retains exclusive handle ownership\n");
+        fflush(stderr);
     }
 }
 

--- a/src/utilities/comm.h
+++ b/src/utilities/comm.h
@@ -93,8 +93,6 @@ public:
     static void run_threads_communicators(int ngpus, bool memcpy_allgather, bool memcpy_send_recv, std::function<void(NCCLCommunicator& comm)> work);
     static std::unique_ptr<CommunicatorThreadsPack> launch_threads_communicators(int ngpus, bool memcpy_allgather, bool memcpy_send_recv, std::function<void(NCCLCommunicator& comm)> work);
 protected:
-    void terminate_nccl();
-
     void scatter_grad(float* value, std::size_t size);
     void scatter_grad(nv_bfloat16* value, std::size_t size);
 


### PR DESCRIPTION
## Scope

This proposes a bounded ownership handoff for NCCL communicator teardown so a stuck finalize path cannot indefinitely block the owning destructor. The helper transfers the NCCL/CUDA handles into cleanup state, joins when cleanup completes within two seconds, and otherwise detaches while retaining exclusive handle ownership. It also adds a CPU-only helper regression executable when Threads is available.

Exact immutable source head: `36c78f4a7e3b4405bb0236c0f131e2e78d090198`
Base: `f5b234c4b95009dfe43ee15181be93bc3fb34563` (`dev`)

Changed paths:
- `CMakeLists.txt`
- `src/testing/test-bounded-cleanup.cpp`
- `src/utilities/bounded_cleanup.h`
- `src/utilities/comm.cpp`
- `src/utilities/comm.h`

## Evidence boundary

- Clean exact-head source review and `git diff --check`: PASS.
- Git bundle verification against the exact base/head: PASS.
- Patch SHA-256: `9A975FA97DF58B9854E9D62B8FA09E3E4D4709D01C63BD729547536788F57EAA`.
- Bundle SHA-256: `D2470EDC133571A82D098C78F7F92D6559649F42CBE2F4233492780560F7B48C`.
- Patch-head Linux CUDA/cuDNN/NCCL/Threads configure/build/test: BLOCKED before configure by host WSL service authorization, exact error `Wsl/Service/E_ACCESSDENIED` (`Access is denied`, process return `0xffffffff`).
- The attempted command was owned by a Windows Job Object with `CREATE_NO_WINDOW`, a 1,300-second finite controller timeout, verified tree cleanup, a 16 GiB virtual-memory cap, and one compile lane. Owned-command SHA-256: `5eb521ea0bec32d9822cc86da1c3df3858e3eec7e4cfd1584888011ae3215d8a`.
- Intended build boundary was explicit CUDA architecture 89, `BUILD_TESTS=ON`, `USE_CUFILE/NVML/MPI=OFF`, target `bounded-cleanup-tests`, then only CTest `^bounded-cleanup-tests$` with `CUDA_VISIBLE_DEVICES` empty.
- Because WSL refused before shell execution, no configure, compile, CTest, GPU runtime, or training workload occurred. No build PASS is claimed.

Related downstream issue: wordingone/ember#1413. This is deliberately non-closing source-only evidence; it does not by itself establish runtime acceptance or downstream issue closure.